### PR TITLE
GPLv3 License Info

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,281 +1,622 @@
-GNU GENERAL PUBLIC LICENSE
-                       Version 2, June 1991
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
 
- Copyright (C) 1989, 1991 Free Software Foundation, Inc., <http://fsf.org/>
- 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
                             Preamble
 
-  The licenses for most software are designed to take away your
-freedom to share and change it.  By contrast, the GNU General Public
-License is intended to guarantee your freedom to share and change free
-software--to make sure the software is free for all its users.  This
-General Public License applies to most of the Free Software
-Foundation's software and to any other program whose authors commit to
-using it.  (Some other Free Software Foundation software is covered by
-the GNU Lesser General Public License instead.)  You can apply it to
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
 your programs, too.
 
   When we speak of free software, we are referring to freedom, not
 price.  Our General Public Licenses are designed to make sure that you
 have the freedom to distribute copies of free software (and charge for
-this service if you wish), that you receive source code or can get it
-if you want it, that you can change the software or use pieces of it
-in new free programs; and that you know you can do these things.
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
 
-  To protect your rights, we need to make restrictions that forbid
-anyone to deny you these rights or to ask you to surrender the rights.
-These restrictions translate to certain responsibilities for you if you
-distribute copies of the software, or if you modify it.
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
 
   For example, if you distribute copies of such a program, whether
-gratis or for a fee, you must give the recipients all the rights that
-you have.  You must make sure that they, too, receive or can get the
-source code.  And you must show them these terms so they know their
-rights.
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
 
-  We protect your rights with two steps: (1) copyright the software, and
-(2) offer you this license which gives you legal permission to copy,
-distribute and/or modify the software.
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
 
-  Also, for each author's protection and ours, we want to make certain
-that everyone understands that there is no warranty for this free
-software.  If the software is modified by someone else and passed on, we
-want its recipients to know that what they have is not the original, so
-that any problems introduced by others will not reflect on the original
-authors' reputations.
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
 
-  Finally, any free program is threatened constantly by software
-patents.  We wish to avoid the danger that redistributors of a free
-program will individually obtain patent licenses, in effect making the
-program proprietary.  To prevent this, we have made it clear that any
-patent must be licensed for everyone's free use or not licensed at all.
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
 
   The precise terms and conditions for copying, distribution and
 modification follow.
 
-                    GNU GENERAL PUBLIC LICENSE
-   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+                       TERMS AND CONDITIONS
 
-  0. This License applies to any program or other work which contains
-a notice placed by the copyright holder saying it may be distributed
-under the terms of this General Public License.  The "Program", below,
-refers to any such program or work, and a "work based on the Program"
-means either the Program or any derivative work under copyright law:
-that is to say, a work containing the Program or a portion of it,
-either verbatim or with modifications and/or translated into another
-language.  (Hereinafter, translation is included without limitation in
-the term "modification".)  Each licensee is addressed as "you".
+  0. Definitions.
 
-Activities other than copying, distribution and modification are not
-covered by this License; they are outside its scope.  The act of
-running the Program is not restricted, and the output from the Program
-is covered only if its contents constitute a work based on the
-Program (independent of having been made by running the Program).
-Whether that is true depends on what the Program does.
+  "This License" refers to version 3 of the GNU General Public License.
 
-  1. You may copy and distribute verbatim copies of the Program's
-source code as you receive it, in any medium, provided that you
-conspicuously and appropriately publish on each copy an appropriate
-copyright notice and disclaimer of warranty; keep intact all the
-notices that refer to this License and to the absence of any warranty;
-and give any other recipients of the Program a copy of this License
-along with the Program.
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
 
-You may charge a fee for the physical act of transferring a copy, and
-you may at your option offer warranty protection in exchange for a fee.
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
 
-  2. You may modify your copy or copies of the Program or any portion
-of it, thus forming a work based on the Program, and copy and
-distribute such modifications or work under the terms of Section 1
-above, provided that you also meet all of these conditions:
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
 
-    a) You must cause the modified files to carry prominent notices
-    stating that you changed the files and the date of any change.
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
 
-    b) You must cause any work that you distribute or publish, that in
-    whole or in part contains or is derived from the Program or any
-    part thereof, to be licensed as a whole at no charge to all third
-    parties under the terms of this License.
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
 
-    c) If the modified program normally reads commands interactively
-    when run, you must cause it, when started running for such
-    interactive use in the most ordinary way, to print or display an
-    announcement including an appropriate copyright notice and a
-    notice that there is no warranty (or else, saying that you provide
-    a warranty) and that users may redistribute the program under
-    these conditions, and telling the user how to view a copy of this
-    License.  (Exception: if the Program itself is interactive but
-    does not normally print such an announcement, your work based on
-    the Program is not required to print an announcement.)
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
 
-These requirements apply to the modified work as a whole.  If
-identifiable sections of that work are not derived from the Program,
-and can be reasonably considered independent and separate works in
-themselves, then this License, and its terms, do not apply to those
-sections when you distribute them as separate works.  But when you
-distribute the same sections as part of a whole which is a work based
-on the Program, the distribution of the whole must be on the terms of
-this License, whose permissions for other licensees extend to the
-entire whole, and thus to each and every part regardless of who wrote it.
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
 
-Thus, it is not the intent of this section to claim rights or contest
-your rights to work written entirely by you; rather, the intent is to
-exercise the right to control the distribution of derivative or
-collective works based on the Program.
+  1. Source Code.
 
-In addition, mere aggregation of another work not based on the Program
-with the Program (or with a work based on the Program) on a volume of
-a storage or distribution medium does not bring the other work under
-the scope of this License.
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
 
-  3. You may copy and distribute the Program (or a work based on it,
-under Section 2) in object code or executable form under the terms of
-Sections 1 and 2 above provided that you also do one of the following:
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
 
-    a) Accompany it with the complete corresponding machine-readable
-    source code, which must be distributed under the terms of Sections
-    1 and 2 above on a medium customarily used for software interchange; or,
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
 
-    b) Accompany it with a written offer, valid for at least three
-    years, to give any third party, for a charge no more than your
-    cost of physically performing source distribution, a complete
-    machine-readable copy of the corresponding source code, to be
-    distributed under the terms of Sections 1 and 2 above on a medium
-    customarily used for software interchange; or,
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
 
-    c) Accompany it with the information you received as to the offer
-    to distribute corresponding source code.  (This alternative is
-    allowed only for noncommercial distribution and only if you
-    received the program in object code or executable form with such
-    an offer, in accord with Subsection b above.)
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
 
-The source code for a work means the preferred form of the work for
-making modifications to it.  For an executable work, complete source
-code means all the source code for all modules it contains, plus any
-associated interface definition files, plus the scripts used to
-control compilation and installation of the executable.  However, as a
-special exception, the source code distributed need not include
-anything that is normally distributed (in either source or binary
-form) with the major components (compiler, kernel, and so on) of the
-operating system on which the executable runs, unless that component
-itself accompanies the executable.
+  The Corresponding Source for a work in source code form is that
+same work.
 
-If distribution of executable or object code is made by offering
-access to copy from a designated place, then offering equivalent
-access to copy the source code from the same place counts as
-distribution of the source code, even though third parties are not
-compelled to copy the source along with the object code.
+  2. Basic Permissions.
 
-  4. You may not copy, modify, sublicense, or distribute the Program
-except as expressly provided under this License.  Any attempt
-otherwise to copy, modify, sublicense or distribute the Program is
-void, and will automatically terminate your rights under this License.
-However, parties who have received copies, or rights, from you under
-this License will not have their licenses terminated so long as such
-parties remain in full compliance.
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
 
-  5. You are not required to accept this License, since you have not
-signed it.  However, nothing else grants you permission to modify or
-distribute the Program or its derivative works.  These actions are
-prohibited by law if you do not accept this License.  Therefore, by
-modifying or distributing the Program (or any work based on the
-Program), you indicate your acceptance of this License to do so, and
-all its terms and conditions for copying, distributing or modifying
-the Program or works based on it.
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
 
-  6. Each time you redistribute the Program (or any work based on the
-Program), the recipient automatically receives a license from the
-original licensor to copy, distribute or modify the Program subject to
-these terms and conditions.  You may not impose any further
-restrictions on the recipients' exercise of the rights granted herein.
-You are not responsible for enforcing compliance by third parties to
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
 this License.
 
-  7. If, as a consequence of a court judgment or allegation of patent
-infringement or for any other reason (not limited to patent issues),
-conditions are imposed on you (whether by court order, agreement or
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
 otherwise) that contradict the conditions of this License, they do not
-excuse you from the conditions of this License.  If you cannot
-distribute so as to satisfy simultaneously your obligations under this
-License and any other pertinent obligations, then as a consequence you
-may not distribute the Program at all.  For example, if a patent
-license would not permit royalty-free redistribution of the Program by
-all those who receive copies directly or indirectly through you, then
-the only way you could satisfy both it and this License would be to
-refrain entirely from distribution of the Program.
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
 
-If any portion of this section is held invalid or unenforceable under
-any particular circumstance, the balance of the section is intended to
-apply and the section as a whole is intended to apply in other
-circumstances.
+  13. Use with the GNU Affero General Public License.
 
-It is not the purpose of this section to induce you to infringe any
-patents or other property right claims or to contest validity of any
-such claims; this section has the sole purpose of protecting the
-integrity of the free software distribution system, which is
-implemented by public license practices.  Many people have made
-generous contributions to the wide range of software distributed
-through that system in reliance on consistent application of that
-system; it is up to the author/donor to decide if he or she is willing
-to distribute software through any other system and a licensee cannot
-impose that choice.
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
 
-This section is intended to make thoroughly clear what is believed to
-be a consequence of the rest of this License.
+  14. Revised Versions of this License.
 
-  8. If the distribution and/or use of the Program is restricted in
-certain countries either by patents or by copyrighted interfaces, the
-original copyright holder who places the Program under this License
-may add an explicit geographical distribution limitation excluding
-those countries, so that distribution is permitted only in or among
-countries not thus excluded.  In such case, this License incorporates
-the limitation as if written in the body of this License.
-
-  9. The Free Software Foundation may publish revised and/or new versions
-of the General Public License from time to time.  Such new versions will
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
 be similar in spirit to the present version, but may differ in detail to
 address new problems or concerns.
 
-Each version is given a distinguishing version number.  If the Program
-specifies a version number of this License which applies to it and "any
-later version", you have the option of following the terms and conditions
-either of that version or of any later version published by the Free
-Software Foundation.  If the Program does not specify a version number of
-this License, you may choose any version ever published by the Free Software
-Foundation.
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
 
-  10. If you wish to incorporate parts of the Program into other free
-programs whose distribution conditions are different, write to the author
-to ask for permission.  For software which is copyrighted by the Free
-Software Foundation, write to the Free Software Foundation; we sometimes
-make exceptions for this.  Our decision will be guided by the two goals
-of preserving the free status of all derivatives of our free software and
-of promoting the sharing and reuse of software generally.
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
 
-                            NO WARRANTY
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
 
-  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
-FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
-OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
-PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
-OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
-TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
-PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
-REPAIR OR CORRECTION.
+  15. Disclaimer of Warranty.
 
-  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
-WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
-REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
-INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
-OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
-TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
-YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
-PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
-POSSIBILITY OF SUCH DAMAGES.
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
 
                      END OF TERMS AND CONDITIONS
 
@@ -287,15 +628,15 @@ free software which everyone can redistribute and change under these terms.
 
   To do so, attach the following notices to the program.  It is safest
 to attach them to the start of each source file to most effectively
-convey the exclusion of warranty; and each file should have at least
+state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
-    {description}
-    Copyright (C) {year}  {fullname}
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
 
-    This program is free software; you can redistribute it and/or modify
+    This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
-    the Free Software Foundation; either version 2 of the License, or
+    the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
     This program is distributed in the hope that it will be useful,
@@ -303,38 +644,31 @@ the "copyright" line and a pointer to where the full notice is found.
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
-    You should have received a copy of the GNU General Public License along
-    with this program; if not, write to the Free Software Foundation, Inc.,
-    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 Also add information on how to contact you by electronic and paper mail.
 
-If the program is interactive, make it output a short notice like this
-when it starts in an interactive mode:
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
 
-    Gnomovision version 69, Copyright (C) year name of author
-    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
     This is free software, and you are welcome to redistribute it
     under certain conditions; type `show c' for details.
 
 The hypothetical commands `show w' and `show c' should show the appropriate
-parts of the General Public License.  Of course, the commands you use may
-be called something other than `show w' and `show c'; they could even be
-mouse-clicks or menu items--whatever suits your program.
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
 
-You should also get your employer (if you work as a programmer) or your
-school, if any, to sign a "copyright disclaimer" for the program, if
-necessary.  Here is a sample; alter the names:
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<http://www.gnu.org/licenses/>.
 
-  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
-  `Gnomovision' (which makes passes at compilers) written by James Hacker.
-
-  {signature of Ty Coon}, 1 April 1989
-  Ty Coon, President of Vice
-
-This General Public License does not permit incorporating your program into
-proprietary programs.  If your program is a subroutine library, you may
-consider it more useful to permit linking proprietary applications with the
-library.  If this is what you want to do, use the GNU Lesser General
-Public License instead of this License.
-
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<http://www.gnu.org/philosophy/why-not-lgpl.html>.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
 # topodroid
-TopoDroid code base
+
+TopoDroid is an Open Source app for cave survey with DistoX on Android devices.
+
+
+## License
+
+Copyright (C) 2010 - 2016  Marco Corvi
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/assets/man/manual00.htm
+++ b/assets/man/manual00.htm
@@ -36,12 +36,18 @@ Due to limited resources, the apk cannot be fully tested. It is advisable to ins
 <li>If you have a question or a feature request, send an enail to topodroid mailing list</li>
 </ul><br><p>
 
+<h4>License</h4>
+<p>This program is <i>free software</i>: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or any later version.</p>
+
+<p>You should have received a copy of the GNU General Public License along with this program.  If not, see <a href="http://gnu.org/licenses/">http://gnu.org/licenses/</a>.</p>
+
+<p><b>Website:</b> <a href="https://sites.google.com/site/speleoapps/">https://sites.google.com/site/speleoapps/</a><br>
+<b>Sources:</b> <a href="https://github.com/marcocorvi/topodroid">https://github.com/marcocorvi/topodroid</a></p>
+
+
 <hr>
 This user manual is maintained with the help of V. Georgiev<br>
 Translations: G. Chardin (french), V. Georgiev (bulgarian), M. Guerrero (spanish), A. Kozhenkov (russian), T. Mueller (german), and F. Toso (italian).<br><p>
-
-Website: http://sites.google.com/speleoapps<br>
-Sources: https://github.com/marcocorvi/topodroid<br><p>
 
 <a href="manual01.htm">Introduction &gt;</a>
 

--- a/src/com/topodroid/DistoX/Archiver.java
+++ b/src/com/topodroid/DistoX/Archiver.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid survey archiver
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/AverageLeg.java
+++ b/src/com/topodroid/DistoX/AverageLeg.java
@@ -5,7 +5,7 @@
  *
  * @grief average of leg shots
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/AzimuthDialDialog.java
+++ b/src/com/topodroid/DistoX/AzimuthDialDialog.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid survey azimuth dialog 
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/BezierCurve.java
+++ b/src/com/topodroid/DistoX/BezierCurve.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid cubic bezier curve (spline)
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/BezierInterpolator.java
+++ b/src/com/topodroid/DistoX/BezierInterpolator.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid cubic bezier interpolator
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  *

--- a/src/com/topodroid/DistoX/BezierPoint.java
+++ b/src/com/topodroid/DistoX/BezierPoint.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid a 2D point on the canvas
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/CWDActivity.java
+++ b/src/com/topodroid/DistoX/CWDActivity.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid CWD activity
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/CalibActivity.java
+++ b/src/com/topodroid/DistoX/CalibActivity.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid calib activity
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/CalibCBlock.java
+++ b/src/com/topodroid/DistoX/CalibCBlock.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid DistoX calibration data
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/CalibCBlockAdapter.java
+++ b/src/com/topodroid/DistoX/CalibCBlockAdapter.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid adapter for calibration data
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  */
 package com.topodroid.DistoX;

--- a/src/com/topodroid/DistoX/CalibCoeffDialog.java
+++ b/src/com/topodroid/DistoX/CalibCoeffDialog.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid DistoX calibration coefficients display dialog
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/CalibComputer.java
+++ b/src/com/topodroid/DistoX/CalibComputer.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid calibration coefficient computation
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/CalibCoverageDialog.java
+++ b/src/com/topodroid/DistoX/CalibCoverageDialog.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid calibration data distribution display
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/CalibGMDialog.java
+++ b/src/com/topodroid/DistoX/CalibGMDialog.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid calibration data dialog (to assign the group number)
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/CalibImportDialog.java
+++ b/src/com/topodroid/DistoX/CalibImportDialog.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid import file list dialog
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/CalibInfo.java
+++ b/src/com/topodroid/DistoX/CalibInfo.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid calib info (name, date, comment etc)
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/CalibListDialog.java
+++ b/src/com/topodroid/DistoX/CalibListDialog.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid calibs list for a device
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/CalibReadTask.java
+++ b/src/com/topodroid/DistoX/CalibReadTask.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid DistoX calib coeff read task
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/CalibResult.java
+++ b/src/com/topodroid/DistoX/CalibResult.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid calib info (name, date, comment etc)
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/CalibToggleTask.java
+++ b/src/com/topodroid/DistoX/CalibToggleTask.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid DistoX calib mode toggle task
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/CalibValidateListDialog.java
+++ b/src/com/topodroid/DistoX/CalibValidateListDialog.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid calibs list to validate a calibration
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/CalibValidateResultDialog.java
+++ b/src/com/topodroid/DistoX/CalibValidateResultDialog.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid DistoX calibration validation results
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/Calibration.java
+++ b/src/com/topodroid/DistoX/Calibration.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid DistoX calibration algorithm
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * This software is adapted from TopoLinux implementation,

--- a/src/com/topodroid/DistoX/ConnectDialog.java
+++ b/src/com/topodroid/DistoX/ConnectDialog.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid Connection dialog with another TopoDroid
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/ConnectionHandler.java
+++ b/src/com/topodroid/DistoX/ConnectionHandler.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid lister interface
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/ConvertTdr2Th2Task.java
+++ b/src/com/topodroid/DistoX/ConvertTdr2Th2Task.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid drawing: save drawing in therion format
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/ConvexHull.java
+++ b/src/com/topodroid/DistoX/ConvexHull.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid main 3d convex hull
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/CurrentStation.java
+++ b/src/com/topodroid/DistoX/CurrentStation.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid current station
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/CurrentStationDialog.java
+++ b/src/com/topodroid/DistoX/CurrentStationDialog.java
@@ -9,7 +9,7 @@
  * a station on it or pop one from it
  *
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/CutNPaste.java
+++ b/src/com/topodroid/DistoX/CutNPaste.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid shot stations cut-n-paste
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/DataDownloadTask.java
+++ b/src/com/topodroid/DistoX/DataDownloadTask.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid one-shot download distoX data
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/DataDownloader.java
+++ b/src/com/topodroid/DistoX/DataDownloader.java
@@ -6,7 +6,7 @@
  * @brief TopoDroid survey shots data downloader (continuous mode)
  *
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/DataHelper.java
+++ b/src/com/topodroid/DistoX/DataHelper.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid SQLite database manager
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/DataListener.java
+++ b/src/com/topodroid/DistoX/DataListener.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid lister interface
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/Device.java
+++ b/src/com/topodroid/DistoX/Device.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid DistoX device object
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/DeviceA3InfoDialog.java
+++ b/src/com/topodroid/DistoX/DeviceA3InfoDialog.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid DistoX A3 device info dialog
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/DeviceA3MemoryDialog.java
+++ b/src/com/topodroid/DistoX/DeviceA3MemoryDialog.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid DistoX A3 device memory dialog
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/DeviceActivity.java
+++ b/src/com/topodroid/DistoX/DeviceActivity.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid DistoX device activity
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/DeviceHelper.java
+++ b/src/com/topodroid/DistoX/DeviceHelper.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid SQLite "device" database manager
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/DeviceList.java
+++ b/src/com/topodroid/DistoX/DeviceList.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid DistoX device list activity
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/DeviceNameDialog.java
+++ b/src/com/topodroid/DistoX/DeviceNameDialog.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid DistoX X310 device info dialog
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/DeviceRemoteDialog.java
+++ b/src/com/topodroid/DistoX/DeviceRemoteDialog.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid DistoX X310 device remote control
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/DeviceUtil.java
+++ b/src/com/topodroid/DistoX/DeviceUtil.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid DistoX device utility
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/DeviceX310InfoDialog.java
+++ b/src/com/topodroid/DistoX/DeviceX310InfoDialog.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid DistoX X310 device info dialog
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/DeviceX310MemoryDialog.java
+++ b/src/com/topodroid/DistoX/DeviceX310MemoryDialog.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid DistoX X310 device memory dialog
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/DisplayMode.java
+++ b/src/com/topodroid/DistoX/DisplayMode.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid drawing: display mode consts
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/DistoXAnnotations.java
+++ b/src/com/topodroid/DistoX/DistoXAnnotations.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid survey shot dialog
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/DistoXComm.java
+++ b/src/com/topodroid/DistoX/DistoXComm.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid-DistoX BlueTooth communication 
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/DistoXDBlock.java
+++ b/src/com/topodroid/DistoX/DistoXDBlock.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid DistoX survey data
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/DistoXDBlockAdapter.java
+++ b/src/com/topodroid/DistoX/DistoXDBlockAdapter.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid adapter for survey data
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/DistoXManualDialog.java
+++ b/src/com/topodroid/DistoX/DistoXManualDialog.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid survey shot dialog
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/DistoXNum.java
+++ b/src/com/topodroid/DistoX/DistoXNum.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid centerline computation
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/DistoXProtocol.java
+++ b/src/com/topodroid/DistoX/DistoXProtocol.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid TopoDroid-DistoX communication protocol
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/DistoXStatDialog.java
+++ b/src/com/topodroid/DistoX/DistoXStatDialog.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid stats display dialog
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/DistoXStationName.java
+++ b/src/com/topodroid/DistoX/DistoXStationName.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid station name increment (static)
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/DrawingActivity.java
+++ b/src/com/topodroid/DistoX/DrawingActivity.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid main drawing activity
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/DrawingAreaDialog.java
+++ b/src/com/topodroid/DistoX/DrawingAreaDialog.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid sketch line attributes editing dialog
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/DrawingAreaPath.java
+++ b/src/com/topodroid/DistoX/DrawingAreaPath.java
@@ -8,7 +8,7 @@
  * The area border (line) path id DrawingPath.mPath
  *
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/DrawingBrush.java
+++ b/src/com/topodroid/DistoX/DrawingBrush.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid drawing: brush base class
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  */
 package com.topodroid.DistoX;

--- a/src/com/topodroid/DistoX/DrawingBrushPaths.java
+++ b/src/com/topodroid/DistoX/DrawingBrushPaths.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid drawing: brushes (points and lines)
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/DrawingCommandManager.java
+++ b/src/com/topodroid/DistoX/DrawingCommandManager.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid drawing: commands manager
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/DrawingDxf.java
+++ b/src/com/topodroid/DistoX/DrawingDxf.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid drawing: dxf export
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/DrawingIO.java
+++ b/src/com/topodroid/DistoX/DrawingIO.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid drawing: drawing I/O
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/DrawingLabelDialog.java
+++ b/src/com/topodroid/DistoX/DrawingLabelDialog.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid drawing: dialog for the text of a label-point
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/DrawingLabelPath.java
+++ b/src/com/topodroid/DistoX/DrawingLabelPath.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid drawing: label-point
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * 
  */

--- a/src/com/topodroid/DistoX/DrawingLineDialog.java
+++ b/src/com/topodroid/DistoX/DrawingLineDialog.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid sketch line attributes editing dialog
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/DrawingLinePath.java
+++ b/src/com/topodroid/DistoX/DrawingLinePath.java
@@ -8,7 +8,7 @@
  * The line path id DrawingPath.mPath
  *
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/DrawingLineSectionDialog.java
+++ b/src/com/topodroid/DistoX/DrawingLineSectionDialog.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid sketch line section dialog 
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/DrawingModeDialog.java
+++ b/src/com/topodroid/DistoX/DrawingModeDialog.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid drawing: display mode dialog
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/DrawingPath.java
+++ b/src/com/topodroid/DistoX/DrawingPath.java
@@ -10,7 +10,7 @@
  * previewPath path is a line with "many" points
  *
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/DrawingPenBrush.java
+++ b/src/com/topodroid/DistoX/DrawingPenBrush.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid drawing: pen base class
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/DrawingPointDialog.java
+++ b/src/com/topodroid/DistoX/DrawingPointDialog.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid sketch point attributes editing dialog
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/DrawingPointLinePath.java
+++ b/src/com/topodroid/DistoX/DrawingPointLinePath.java
@@ -8,7 +8,7 @@
  * The area border (line) path id DrawingPath.mPath
  *
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/DrawingPointPath.java
+++ b/src/com/topodroid/DistoX/DrawingPointPath.java
@@ -6,7 +6,7 @@
  * @brief TopoDroid drawing: points
  *        type DRAWING_PATH_POINT
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/DrawingProfileFlipDialog.java
+++ b/src/com/topodroid/DistoX/DrawingProfileFlipDialog.java
@@ -9,7 +9,7 @@
  * a station on it or pop one from it
  *
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/DrawingShotDialog.java
+++ b/src/com/topodroid/DistoX/DrawingShotDialog.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid drawing: dialog for a survey shot: editing comment, extend and flag
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/DrawingStationDialog.java
+++ b/src/com/topodroid/DistoX/DrawingStationDialog.java
@@ -8,7 +8,7 @@
  * for when station points are not automatically added
  *
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/DrawingStationName.java
+++ b/src/com/topodroid/DistoX/DrawingStationName.java
@@ -6,7 +6,7 @@
  * @brief TopoDroid drawing station name (this is not a station point) 
 *        type: DRAWING_PATH_NAME
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  */
 package com.topodroid.DistoX;

--- a/src/com/topodroid/DistoX/DrawingStationPath.java
+++ b/src/com/topodroid/DistoX/DrawingStationPath.java
@@ -6,7 +6,7 @@
  * @brief TopoDroid drawing: station point 
  *        type DRAWING_PATH_STATION
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/DrawingSurface.java
+++ b/src/com/topodroid/DistoX/DrawingSurface.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid drawing: drawing surface (canvas)
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/DrawingSvg.java
+++ b/src/com/topodroid/DistoX/DrawingSvg.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid drawing: dxf export
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/DrawingUtil.java
+++ b/src/com/topodroid/DistoX/DrawingUtil.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid drawing utilities
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/EnableSymbol.java
+++ b/src/com/topodroid/DistoX/EnableSymbol.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid enabled symbol(s)
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/EraseAction.java
+++ b/src/com/topodroid/DistoX/EraseAction.java
@@ -6,7 +6,7 @@
  * @brief TopoDroid drawing: single erase action
  * 
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/EraseCommand.java
+++ b/src/com/topodroid/DistoX/EraseCommand.java
@@ -6,7 +6,7 @@
  * @brief TopoDroid drawing: atomic erase command
  * 
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/ExportDialog.java
+++ b/src/com/topodroid/DistoX/ExportDialog.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid survey export dialog
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/FirmwareDialog.java
+++ b/src/com/topodroid/DistoX/FirmwareDialog.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid DistoX X310 device firmware dialog
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/FirmwareFileDialog.java
+++ b/src/com/topodroid/DistoX/FirmwareFileDialog.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid firmware file list dialog
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/FixedAdapter.java
+++ b/src/com/topodroid/DistoX/FixedAdapter.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid adapter for fixed station info
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/FixedDialog.java
+++ b/src/com/topodroid/DistoX/FixedDialog.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid survey fix point edit dialog
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/FixedInfo.java
+++ b/src/com/topodroid/DistoX/FixedInfo.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid fixed stations (GPS-localized stations)
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/GMActivity.java
+++ b/src/com/topodroid/DistoX/GMActivity.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid calibration data activity
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/GeomagLib.java
+++ b/src/com/topodroid/DistoX/GeomagLib.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid World Magnetic Model 
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * Implemented after GeomagneticLibrary.c by

--- a/src/com/topodroid/DistoX/Geometry2D.java
+++ b/src/com/topodroid/DistoX/Geometry2D.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid  2d geometry
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/HelpAdapter.java
+++ b/src/com/topodroid/DistoX/HelpAdapter.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid help dialog items adapter
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/HelpEntry.java
+++ b/src/com/topodroid/DistoX/HelpEntry.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid help dialog 
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/HorizontalButtonView.java
+++ b/src/com/topodroid/DistoX/HorizontalButtonView.java
@@ -7,7 +7,7 @@
  *
  * @brief TopoDroid button bar
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/HorizontalListView.java
+++ b/src/com/topodroid/DistoX/HorizontalListView.java
@@ -7,7 +7,7 @@
  *
  * @brief TopoDroid button bar buttons view
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/IBrush.java
+++ b/src/com/topodroid/DistoX/IBrush.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid drawing: brush interface
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/ICanvasCommand.java
+++ b/src/com/topodroid/DistoX/ICanvasCommand.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid drawing: canvas command interface
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/IConnListener.java
+++ b/src/com/topodroid/DistoX/IConnListener.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid connection listener interface
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/IEnableButtons.java
+++ b/src/com/topodroid/DistoX/IEnableButtons.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid drawing: brush interface
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/IExporter.java
+++ b/src/com/topodroid/DistoX/IExporter.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid lister interface
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/ILabelAdder.java
+++ b/src/com/topodroid/DistoX/ILabelAdder.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid label adder interfare
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/ILister.java
+++ b/src/com/topodroid/DistoX/ILister.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid lister interface
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/INewPlot.java
+++ b/src/com/topodroid/DistoX/INewPlot.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid NewPlot interface
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/IZoomer.java
+++ b/src/com/topodroid/DistoX/IZoomer.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid zoomer interface
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/ImportDialog.java
+++ b/src/com/topodroid/DistoX/ImportDialog.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid import file list dialog
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/ImportParser.java
+++ b/src/com/topodroid/DistoX/ImportParser.java
@@ -6,7 +6,7 @@
  * @brief TopoDroid import parser
  *
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * ----------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/ItemAdapter.java
+++ b/src/com/topodroid/DistoX/ItemAdapter.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid 
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/ItemButton.java
+++ b/src/com/topodroid/DistoX/ItemButton.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid drawing: button for a symbol item
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/ItemDrawer.java
+++ b/src/com/topodroid/DistoX/ItemDrawer.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid label adder interfare
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/ItemPickerDialog.java
+++ b/src/com/topodroid/DistoX/ItemPickerDialog.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid drawing
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/ItemRecentDialog.java
+++ b/src/com/topodroid/DistoX/ItemRecentDialog.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid drawing
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/ItemSymbol.java
+++ b/src/com/topodroid/DistoX/ItemSymbol.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid drawing
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/LRUD.java
+++ b/src/com/topodroid/DistoX/LRUD.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid drawing: button for an area type
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/Line3D.java
+++ b/src/com/topodroid/DistoX/Line3D.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid sketch 3D line
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/LinePoint.java
+++ b/src/com/topodroid/DistoX/LinePoint.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid drawing: a point on a line
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/ListItemAdapter.java
+++ b/src/com/topodroid/DistoX/ListItemAdapter.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid adapter for calibration data
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  */
 package com.topodroid.DistoX;

--- a/src/com/topodroid/DistoX/ListerHandler.java
+++ b/src/com/topodroid/DistoX/ListerHandler.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid handler for a data lister
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/ListerSet.java
+++ b/src/com/topodroid/DistoX/ListerSet.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid lister set
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/ListerSetHandler.java
+++ b/src/com/topodroid/DistoX/ListerSetHandler.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid handler for a set of listers
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/LocationDialog.java
+++ b/src/com/topodroid/DistoX/LocationDialog.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid GPS-location for fixed stations: new-entry and listing
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/LongLatAltDialog.java
+++ b/src/com/topodroid/DistoX/LongLatAltDialog.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid dialog to confirm/enter long-lat data
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/MagDate.java
+++ b/src/com/topodroid/DistoX/MagDate.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid World Magnetic Model 
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * Implemented after GeomagneticLibrary.c by

--- a/src/com/topodroid/DistoX/MagElement.java
+++ b/src/com/topodroid/DistoX/MagElement.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid World Magnetic Model 
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * Implemented after GeomagneticLibrary.c by

--- a/src/com/topodroid/DistoX/MagEllipsoid.java
+++ b/src/com/topodroid/DistoX/MagEllipsoid.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid World Magnetic Model 
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * Implemented after GeomagneticLibrary.c by

--- a/src/com/topodroid/DistoX/MagErrors.java
+++ b/src/com/topodroid/DistoX/MagErrors.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid World Magnetic Model 
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * Implemented after GeomagneticLibrary.c by

--- a/src/com/topodroid/DistoX/MagGeodetic.java
+++ b/src/com/topodroid/DistoX/MagGeodetic.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid World Magnetic Model 
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * Implemented after GeomagneticLibrary.c by

--- a/src/com/topodroid/DistoX/MagGeoid.java
+++ b/src/com/topodroid/DistoX/MagGeoid.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid World Magnetic Model 
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * Implemented after GeomagneticLibrary.c by

--- a/src/com/topodroid/DistoX/MagGradient.java
+++ b/src/com/topodroid/DistoX/MagGradient.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid World Magnetic Model 
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * Implemented after GeomagneticLibrary.c by

--- a/src/com/topodroid/DistoX/MagHarmonic.java
+++ b/src/com/topodroid/DistoX/MagHarmonic.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid World Magnetic Model 
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * Implemented after GeomagneticLibrary.c by

--- a/src/com/topodroid/DistoX/MagLatLong.java
+++ b/src/com/topodroid/DistoX/MagLatLong.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid World Magnetic Model 
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * Implemented after GeomagneticLibrary.c by

--- a/src/com/topodroid/DistoX/MagLegendre.java
+++ b/src/com/topodroid/DistoX/MagLegendre.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid World Magnetic Model 
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * Implemented after GeomagneticLibrary.c by

--- a/src/com/topodroid/DistoX/MagModel.java
+++ b/src/com/topodroid/DistoX/MagModel.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid World Magnetic Model 
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * Implemented after GeomagneticLibrary.c by

--- a/src/com/topodroid/DistoX/MagSpherical.java
+++ b/src/com/topodroid/DistoX/MagSpherical.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid World Magnetic Model 
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * Implemented after GeomagneticLibrary.c by

--- a/src/com/topodroid/DistoX/MagUTMParams.java
+++ b/src/com/topodroid/DistoX/MagUTMParams.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid World Magnetic Model 
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * Implemented after GeomagneticLibrary.c by

--- a/src/com/topodroid/DistoX/MagUtil.java
+++ b/src/com/topodroid/DistoX/MagUtil.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid World Magnetic Model 
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * Implemented after GeomagneticLibrary.c by

--- a/src/com/topodroid/DistoX/MagVector.java
+++ b/src/com/topodroid/DistoX/MagVector.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid World Magnetic Model 
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * Implemented after GeomagneticLibrary.c by

--- a/src/com/topodroid/DistoX/Matrix.java
+++ b/src/com/topodroid/DistoX/Matrix.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid 3x3 matrix
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * This software is adapted from TopoLinux implementation,

--- a/src/com/topodroid/DistoX/MemoryListDialog.java
+++ b/src/com/topodroid/DistoX/MemoryListDialog.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid list distox memory
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/MemoryOctet.java
+++ b/src/com/topodroid/DistoX/MemoryOctet.java
@@ -5,7 +5,7 @@
  *
  * @brief 8-byte data in the distox memory
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/MobileTopographerDialog.java
+++ b/src/com/topodroid/DistoX/MobileTopographerDialog.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid MobileTopographer pointlist files dialog
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/MyCheckBox.java
+++ b/src/com/topodroid/DistoX/MyCheckBox.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid checkbox button
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  */
 package com.topodroid.DistoX;

--- a/src/com/topodroid/DistoX/MyDateSetListener.java
+++ b/src/com/topodroid/DistoX/MyDateSetListener.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid date setter
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/MyEditPreference.java
+++ b/src/com/topodroid/DistoX/MyEditPreference.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid option value
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  */
 package com.topodroid.DistoX;

--- a/src/com/topodroid/DistoX/MyKeyboard.java
+++ b/src/com/topodroid/DistoX/MyKeyboard.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid numerical keyboard dialog
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/MyListPreference.java
+++ b/src/com/topodroid/DistoX/MyListPreference.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid option list
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  */
 package com.topodroid.DistoX;

--- a/src/com/topodroid/DistoX/NumAzimuth.java
+++ b/src/com/topodroid/DistoX/NumAzimuth.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid survey reduction leg-azimuth at a station
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/NumBranch.java
+++ b/src/com/topodroid/DistoX/NumBranch.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid survey reduction branch of shots
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/NumCycle.java
+++ b/src/com/topodroid/DistoX/NumCycle.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid survey reduction cycle of the survey net
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/NumNode.java
+++ b/src/com/topodroid/DistoX/NumNode.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid survey reduction node of the survey net
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/NumShot.java
+++ b/src/com/topodroid/DistoX/NumShot.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid survey reduction shot
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/NumSplay.java
+++ b/src/com/topodroid/DistoX/NumSplay.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid survey reduction splay shot
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/NumStation.java
+++ b/src/com/topodroid/DistoX/NumStation.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid survey reduction station
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/NumStationSet.java
+++ b/src/com/topodroid/DistoX/NumStationSet.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid survey stations container (RB-tree)
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/NumSurveyPoint.java
+++ b/src/com/topodroid/DistoX/NumSurveyPoint.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid survey reduction point
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/OnItemSelectedListener.java
+++ b/src/com/topodroid/DistoX/OnItemSelectedListener.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid drawing: item type selection listener
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/OrientationWidget.java
+++ b/src/com/topodroid/DistoX/OrientationWidget.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid orientation widgets
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/OverviewActivity.java
+++ b/src/com/topodroid/DistoX/OverviewActivity.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid sketch overview activity
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/PTDrawing.java
+++ b/src/com/topodroid/DistoX/PTDrawing.java
@@ -5,7 +5,7 @@
  *
  * @brief PocketTopo file IO
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  */
 package com.topodroid.DistoX;

--- a/src/com/topodroid/DistoX/PTElement.java
+++ b/src/com/topodroid/DistoX/PTElement.java
@@ -5,7 +5,7 @@
  *
  * @brief PocketTopo file IO
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  */
 package com.topodroid.DistoX;

--- a/src/com/topodroid/DistoX/PTFile.java
+++ b/src/com/topodroid/DistoX/PTFile.java
@@ -5,7 +5,7 @@
  *
  * @brief PocketTopo file IO
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  */
 package com.topodroid.DistoX;

--- a/src/com/topodroid/DistoX/PTId.java
+++ b/src/com/topodroid/DistoX/PTId.java
@@ -5,7 +5,7 @@
  *
  * @brief PocketTopo file IO
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  */
 package com.topodroid.DistoX;

--- a/src/com/topodroid/DistoX/PTMapping.java
+++ b/src/com/topodroid/DistoX/PTMapping.java
@@ -5,7 +5,7 @@
  *
  * @brief PocketTopo file IO
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  */
 package com.topodroid.DistoX;

--- a/src/com/topodroid/DistoX/PTPoint.java
+++ b/src/com/topodroid/DistoX/PTPoint.java
@@ -5,7 +5,7 @@
  *
  * @brief PocketTopo file IO
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  */
 package com.topodroid.DistoX;

--- a/src/com/topodroid/DistoX/PTPolygonElement.java
+++ b/src/com/topodroid/DistoX/PTPolygonElement.java
@@ -5,7 +5,7 @@
  *
  * @brief PocketTopo file IO
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  */
 package com.topodroid.DistoX;

--- a/src/com/topodroid/DistoX/PTReference.java
+++ b/src/com/topodroid/DistoX/PTReference.java
@@ -5,7 +5,7 @@
  *
  * @brief PocketTopo file IO
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  */
 package com.topodroid.DistoX;

--- a/src/com/topodroid/DistoX/PTShot.java
+++ b/src/com/topodroid/DistoX/PTShot.java
@@ -5,7 +5,7 @@
  *
  * @brief PocketTopo file IO
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  */
 package com.topodroid.DistoX;

--- a/src/com/topodroid/DistoX/PTString.java
+++ b/src/com/topodroid/DistoX/PTString.java
@@ -1,7 +1,7 @@
 /** @file PTString.java
  *
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  */
 package com.topodroid.DistoX;

--- a/src/com/topodroid/DistoX/PTTrip.java
+++ b/src/com/topodroid/DistoX/PTTrip.java
@@ -5,7 +5,7 @@
  *
  * @brief PocketTopo file IO
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  */
 package com.topodroid.DistoX;

--- a/src/com/topodroid/DistoX/PTXSectionElement.java
+++ b/src/com/topodroid/DistoX/PTXSectionElement.java
@@ -5,7 +5,7 @@
  *
  * @brief PocketTopo file IO
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  */
 package com.topodroid.DistoX;

--- a/src/com/topodroid/DistoX/ParserCompass.java
+++ b/src/com/topodroid/DistoX/ParserCompass.java
@@ -6,7 +6,7 @@
  * @brief TopoDroid Compass parser
  *
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * ----------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/ParserException.java
+++ b/src/com/topodroid/DistoX/ParserException.java
@@ -6,7 +6,7 @@
  * @brief TopoDroid parser exception
  *
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * ----------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/ParserPocketTopo.java
+++ b/src/com/topodroid/DistoX/ParserPocketTopo.java
@@ -6,7 +6,7 @@
  * @brief TopoDroid PocketTopo parser
  *
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * ----------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/ParserShot.java
+++ b/src/com/topodroid/DistoX/ParserShot.java
@@ -6,7 +6,7 @@
  * @brief TopoDroid parser shot
  *
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * ----------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/ParserTherion.java
+++ b/src/com/topodroid/DistoX/ParserTherion.java
@@ -6,7 +6,7 @@
  * @brief TopoDroid Therion parser
  *
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * ----------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/ParserTherionState.java
+++ b/src/com/topodroid/DistoX/ParserTherionState.java
@@ -6,7 +6,7 @@
  * @brief TopoDroid state for the Therion parser
  *
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * ----------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/ParserVisualTopo.java
+++ b/src/com/topodroid/DistoX/ParserVisualTopo.java
@@ -6,7 +6,7 @@
  * @brief TopoDroid VisualTopo parser
  *
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * ----------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/PhotoActivity.java
+++ b/src/com/topodroid/DistoX/PhotoActivity.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid survey photo listing
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/PhotoAdapter.java
+++ b/src/com/topodroid/DistoX/PhotoAdapter.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid adapter for survey data
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/PhotoCommentDialog.java
+++ b/src/com/topodroid/DistoX/PhotoCommentDialog.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid photo comment dialog (to enter the comment of the photo)
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/PhotoEditDialog.java
+++ b/src/com/topodroid/DistoX/PhotoEditDialog.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid photo edit dialog 
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/PhotoInfo.java
+++ b/src/com/topodroid/DistoX/PhotoInfo.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid photo info (id, station, comment)
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/PhotoSensorsDialog.java
+++ b/src/com/topodroid/DistoX/PhotoSensorsDialog.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid photo dialog (to enter the name of the photo)
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  */
 package com.topodroid.DistoX;

--- a/src/com/topodroid/DistoX/PlotInfo.java
+++ b/src/com/topodroid/DistoX/PlotInfo.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid sketch metadata
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/PlotListDialog.java
+++ b/src/com/topodroid/DistoX/PlotListDialog.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid option list
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/PlotNewDialog.java
+++ b/src/com/topodroid/DistoX/PlotNewDialog.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid new-plot dialog
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/PlotRecoverDialog.java
+++ b/src/com/topodroid/DistoX/PlotRecoverDialog.java
@@ -9,7 +9,7 @@
  * a station on it or pop one from it
  *
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/PtCmapActivity.java
+++ b/src/com/topodroid/DistoX/PtCmapActivity.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid PocketTopo colormap activity
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/ReconnectTask.java
+++ b/src/com/topodroid/DistoX/ReconnectTask.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid 
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/SaveTh2FileTask.java
+++ b/src/com/topodroid/DistoX/SaveTh2FileTask.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid drawing: save drawing in therion format
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/Scanline.java
+++ b/src/com/topodroid/DistoX/Scanline.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid SQLite loader readfile helper
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/Selection.java
+++ b/src/com/topodroid/DistoX/Selection.java
@@ -5,7 +5,7 @@
  *
  * @brief Selection among drawing items
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * ----------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/SelectionBucket.java
+++ b/src/com/topodroid/DistoX/SelectionBucket.java
@@ -5,7 +5,7 @@
  *
  * @brief SelectionBucket a rectangle of selection points
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * ----------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/SelectionPoint.java
+++ b/src/com/topodroid/DistoX/SelectionPoint.java
@@ -5,7 +5,7 @@
  *
  * @brief a point in the selection set
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  *  CHANGES

--- a/src/com/topodroid/DistoX/SelectionSet.java
+++ b/src/com/topodroid/DistoX/SelectionSet.java
@@ -5,7 +5,7 @@
  *
  * @brief set of selected drawing items
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * ----------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/SensorActivity.java
+++ b/src/com/topodroid/DistoX/SensorActivity.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid DistoX sensor activity
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/SensorAdapter.java
+++ b/src/com/topodroid/DistoX/SensorAdapter.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid adapter for survey data
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/SensorInfo.java
+++ b/src/com/topodroid/DistoX/SensorInfo.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid Sensor info (id, station, comment, value)
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/SensorListActivity.java
+++ b/src/com/topodroid/DistoX/SensorListActivity.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid survey sensor listing
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/ShotActivity.java
+++ b/src/com/topodroid/DistoX/ShotActivity.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid survey shots management
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/ShotDeleteDialog.java
+++ b/src/com/topodroid/DistoX/ShotDeleteDialog.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid photo dialog (to enter the name of the photo)
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  */
 package com.topodroid.DistoX;

--- a/src/com/topodroid/DistoX/ShotDialog.java
+++ b/src/com/topodroid/DistoX/ShotDialog.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid survey shot dialog to enter FROM-TO stations etc.
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/ShotDisplayDialog.java
+++ b/src/com/topodroid/DistoX/ShotDisplayDialog.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid shot-list: display mode dialog
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/ShotNewDialog.java
+++ b/src/com/topodroid/DistoX/ShotNewDialog.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid dialog for a new (manually entered) shot
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/Sketch3dInfo.java
+++ b/src/com/topodroid/DistoX/Sketch3dInfo.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid 3D sketch: path types (points, lines, and areas)
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  */
 package com.topodroid.DistoX;

--- a/src/com/topodroid/DistoX/Sketch3dNewDialog.java
+++ b/src/com/topodroid/DistoX/Sketch3dNewDialog.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid 3d sketch: new-sketch3d dialog
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/SketchActivity.java
+++ b/src/com/topodroid/DistoX/SketchActivity.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid main 3d sketch activity
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/SketchAreaPath.java
+++ b/src/com/topodroid/DistoX/SketchAreaPath.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid 3d sketch: area-path (areas)
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES 

--- a/src/com/topodroid/DistoX/SketchBorder.java
+++ b/src/com/topodroid/DistoX/SketchBorder.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid 3d sketch: surface border
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/SketchDef.java
+++ b/src/com/topodroid/DistoX/SketchDef.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid 3d sketch: defines
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES 

--- a/src/com/topodroid/DistoX/SketchDrawingSurface.java
+++ b/src/com/topodroid/DistoX/SketchDrawingSurface.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid 3d sketch: drawing surface (canvas)
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/SketchDxf.java
+++ b/src/com/topodroid/DistoX/SketchDxf.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid 3d sketch DXF export
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/SketchFixedPath.java
+++ b/src/com/topodroid/DistoX/SketchFixedPath.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid 3d sketch: fixed-line path 
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/SketchLinePath.java
+++ b/src/com/topodroid/DistoX/SketchLinePath.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid 3d sketch: line-path (lines)
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/SketchModeDialog.java
+++ b/src/com/topodroid/DistoX/SketchModeDialog.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid 3d sketch: new-sketch3d dialog
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/SketchModel.java
+++ b/src/com/topodroid/DistoX/SketchModel.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid 3d sketch: sketch 3D model
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/SketchNewShotDialog.java
+++ b/src/com/topodroid/DistoX/SketchNewShotDialog.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid sketch save dialog
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  *

--- a/src/com/topodroid/DistoX/SketchPainter.java
+++ b/src/com/topodroid/DistoX/SketchPainter.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid 3d sketch: path types (points, lines, and areas)
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * 20130220 created
  */

--- a/src/com/topodroid/DistoX/SketchPath.java
+++ b/src/com/topodroid/DistoX/SketchPath.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid 3d sketch: path types (points, lines, and areas)
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * 20130220 created
  */

--- a/src/com/topodroid/DistoX/SketchPointPath.java
+++ b/src/com/topodroid/DistoX/SketchPointPath.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid 3d sketch: points
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/SketchRefinement.java
+++ b/src/com/topodroid/DistoX/SketchRefinement.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid sketch triangle refinement
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/SketchShot.java
+++ b/src/com/topodroid/DistoX/SketchShot.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid 3d sketch: 3d shot between two stations
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/SketchSide.java
+++ b/src/com/topodroid/DistoX/SketchSide.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid 3d sketch: surface vertex (point with index)
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/SketchStationName.java
+++ b/src/com/topodroid/DistoX/SketchStationName.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid 3d sketch: station name (this is not a station point)
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/SketchSurface.java
+++ b/src/com/topodroid/DistoX/SketchSurface.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid 3d sketch: 3D surface 
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/SketchTriangle.java
+++ b/src/com/topodroid/DistoX/SketchTriangle.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid 3d sketch: 3D surface triangle
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/SketchUndo.java
+++ b/src/com/topodroid/DistoX/SketchUndo.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid 3d sketch: undo struct
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES 

--- a/src/com/topodroid/DistoX/SketchVertex.java
+++ b/src/com/topodroid/DistoX/SketchVertex.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid 3d sketch: 3D surface vertex (point with index)
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/SurveyActivity.java
+++ b/src/com/topodroid/DistoX/SurveyActivity.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid survey activity
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/SurveyCalibrationDialog.java
+++ b/src/com/topodroid/DistoX/SurveyCalibrationDialog.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid DistoX X310 device info dialog
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/SurveyInfo.java
+++ b/src/com/topodroid/DistoX/SurveyInfo.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid survey info (name, date, comment etc)
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/SurveyNewDialog.java
+++ b/src/com/topodroid/DistoX/SurveyNewDialog.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid survey activity
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/SurveyRenameDialog.java
+++ b/src/com/topodroid/DistoX/SurveyRenameDialog.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid survey Rename dialog
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/SurveyStat.java
+++ b/src/com/topodroid/DistoX/SurveyStat.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid survey stat info (lengths and counts)
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/SurveyStatDialog.java
+++ b/src/com/topodroid/DistoX/SurveyStatDialog.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid survey stats display dialog
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/Symbol.java
+++ b/src/com/topodroid/DistoX/Symbol.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid drawing symbol: 
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/SymbolAdapter.java
+++ b/src/com/topodroid/DistoX/SymbolAdapter.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid 
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/SymbolArea.java
+++ b/src/com/topodroid/DistoX/SymbolArea.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid drawing: area symbol
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/SymbolAreaLibrary.java
+++ b/src/com/topodroid/DistoX/SymbolAreaLibrary.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid drawing: area symbol library
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/SymbolEnableDialog.java
+++ b/src/com/topodroid/DistoX/SymbolEnableDialog.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid drawing symbol: 
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/SymbolLibrary.java
+++ b/src/com/topodroid/DistoX/SymbolLibrary.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid drawing: area symbol library
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/SymbolLine.java
+++ b/src/com/topodroid/DistoX/SymbolLine.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid drawing: line symbol
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/SymbolLineLibrary.java
+++ b/src/com/topodroid/DistoX/SymbolLineLibrary.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid drawing: line symbol library
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/SymbolPoint.java
+++ b/src/com/topodroid/DistoX/SymbolPoint.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid drawing: point symbol
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/SymbolPointLibrary.java
+++ b/src/com/topodroid/DistoX/SymbolPointLibrary.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid drawing: point symbol library
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/SymbolsPalette.java
+++ b/src/com/topodroid/DistoX/SymbolsPalette.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid missing drawing symbols collections
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/TDLog.java
+++ b/src/com/topodroid/DistoX/TDLog.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid application (consts and prefs)
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/TDMath.java
+++ b/src/com/topodroid/DistoX/TDMath.java
@@ -5,7 +5,7 @@
  *
  * @grief math utilities
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/TDPath.java
+++ b/src/com/topodroid/DistoX/TDPath.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid application paths
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/TDSetting.java
+++ b/src/com/topodroid/DistoX/TDSetting.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid application settings (preferenceces)
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/TopoDroidAbout.java
+++ b/src/com/topodroid/DistoX/TopoDroidAbout.java
@@ -6,7 +6,7 @@
  * @brief TopoDroid about dialog
  *
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * ----------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/TopoDroidActivity.java
+++ b/src/com/topodroid/DistoX/TopoDroidActivity.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid main class: survey/calib list
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/TopoDroidApp.java
+++ b/src/com/topodroid/DistoX/TopoDroidApp.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid application (consts and prefs)
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/TopoDroidConst.java
+++ b/src/com/topodroid/DistoX/TopoDroidConst.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid numerical constants
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/TopoDroidExporter.java
+++ b/src/com/topodroid/DistoX/TopoDroidExporter.java
@@ -5,7 +5,7 @@
  *
  * @grief numerical utilities
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/TopoDroidPreferences.java
+++ b/src/com/topodroid/DistoX/TopoDroidPreferences.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid options dialog
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/TopoDroidTag.java
+++ b/src/com/topodroid/DistoX/TopoDroidTag.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid application (consts and prefs)
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/TopoDroidUtil.java
+++ b/src/com/topodroid/DistoX/TopoDroidUtil.java
@@ -5,7 +5,7 @@
  *
  * @grief numerical utilities
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  */

--- a/src/com/topodroid/DistoX/Triangle.java
+++ b/src/com/topodroid/DistoX/Triangle.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid 3 vector triangle
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * This software is adapted from TopoLinux implementation,

--- a/src/com/topodroid/DistoX/UndeleteDialog.java
+++ b/src/com/topodroid/DistoX/UndeleteDialog.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid undelete survey item activity
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * CHANGES

--- a/src/com/topodroid/DistoX/Vector.java
+++ b/src/com/topodroid/DistoX/Vector.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid 3 vector
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * This software is adapted from TopoLinux implementation,

--- a/src/com/topodroid/DistoX/WMMcoeff.java
+++ b/src/com/topodroid/DistoX/WMMcoeff.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid World Magnetic Model 
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * Implemented after GeomagneticLibrary.c by

--- a/src/com/topodroid/DistoX/WorldMagneticModel.java
+++ b/src/com/topodroid/DistoX/WorldMagneticModel.java
@@ -5,7 +5,7 @@
  *
  * @brief TopoDroid World Magnetic Model 
  * --------------------------------------------------------
- *  Copyright This sowftare is distributed under GPL-3.0 or later
+ *  Copyright: This software is distributed under GPL-3.0 or later
  *  See the file COPYING.
  * --------------------------------------------------------
  * Implemented after GeomagneticLibrary.c by


### PR DESCRIPTION
TopoDroid source code declares "GPLv3 or later" license, but the project `LICENSE` file still contained GPLv2 text left over from the topolinux project.

This pull request:

* includes the full text of the GPLv3 license
* references the license info in the project README and in the user manual
* fixes a spelling error in the copyright statement of all Java source file headers (please update the template in your IDE!)

Thanks for all of your excellent work on this Open Source project over the past years!