### PR TITLE
Taking into consideration space lost to top bar and top menu on 'zoom to fit'.

### DIFF
--- a/src/com/topodroid/DistoX/DrawingWindow.java
+++ b/src/com/topodroid/DistoX/DrawingWindow.java
@@ -4069,11 +4069,11 @@ public class DrawingWindow extends ItemDrawer
   {
     float w = b.right - b.left;
     float h = b.bottom - b.top;
-    float wZoom = TopoDroidApp.mDisplayWidth  / ( 1 + w );
-    float hZoom = TopoDroidApp.mDisplayHeight / ( 1 + h );
+    float wZoom = (float) ( mDrawingSurface.getMeasuredWidth() * 0.9 ) / ( 1 + w );
+    float hZoom = (float) ( ( ( mDrawingSurface.getMeasuredHeight() - mListView.getHeight() ) * 0.9 ) / ( 1 + h ));
     mZoom = ( hZoom < wZoom ) ? hZoom : wZoom;
     mOffset.x = TopoDroidApp.mDisplayWidth  / (2*mZoom) - (b.left + b.right) / 2;
-    mOffset.y = TopoDroidApp.mDisplayHeight / (2*mZoom) - (b.top + b.bottom) / 2;
+    mOffset.y = ( TopoDroidApp.mDisplayHeight + mListView.getHeight() ) / (2*mZoom) - (b.top + b.bottom ) / 2;
     // Log.v("DistoX", "W " + w + " H " + h + " zoom " + mZoom + " X " + mOffset.x + " Y " + mOffset.y );
     mDrawingSurface.setTransform( mOffset.x, mOffset.y, mZoom );
   }


### PR DESCRIPTION
I decided to make a pull request instead of actually pushing this code as I'm just starting to understand Topodroid's code.

In this commit I tried to take into consideration space lost to top bar (_mDrawingSurface_ instead of _TopoDroidApp.mDisplayWidth_), top menu (_mListView.getHeight()_) and adding some breathing space (the magical _0.9_ I used).


