### PR TITLE
Fix manual pages always display default page when accessed from HelpDialog

### DIFF
--- a/src/com/topodroid/DistoX/CalibActivity.java
+++ b/src/com/topodroid/DistoX/CalibActivity.java
@@ -89,6 +89,8 @@ public class CalibActivity extends Activity
                         R.string.help_help
                       };
 
+  private static final int HELP_PAGE = R.string.CalibActivity;
+
   private EditText mEditName;
   private Button mEditDate;
   // private TextView mEditDevice;
@@ -407,8 +409,7 @@ public class CalibActivity extends Activity
       case KeyEvent.KEYCODE_SEARCH:
         return onSearchRequested();
       case KeyEvent.KEYCODE_MENU:   // HARDWRAE MENU (82)
-        String help_page = getResources().getString( R.string.CalibActivity );
-        if ( help_page != null ) UserManualActivity.showHelpPage( this, help_page );
+        UserManualActivity.showHelpPage( this, getResources().getString( HELP_PAGE ));
         return true;
       // case KeyEvent.KEYCODE_VOLUME_UP:   // (24)
       // case KeyEvent.KEYCODE_VOLUME_DOWN: // (25)
@@ -464,7 +465,7 @@ public class CalibActivity extends Activity
       startActivity( intent );
 
     } else if ( p++ == pos ) { // HELP
-      (new HelpDialog(this, izons, menus, help_icons, help_menus, mNrButton1, menus.length ) ).show();
+      new HelpDialog(this, izons, menus, help_icons, help_menus, mNrButton1, menus.length, getResources().getString( HELP_PAGE )).show();
     }
   }
 

--- a/src/com/topodroid/DistoX/DeviceActivity.java
+++ b/src/com/topodroid/DistoX/DeviceActivity.java
@@ -130,6 +130,8 @@ public class DeviceActivity extends Activity
                         R.string.help_help
                       };
 
+  private static final int HELP_PAGE = R.string.DeviceActivity;
+
   // private ArrayAdapter<String> mArrayAdapter;
   private ListItemAdapter mArrayAdapter;
   private ListView mList;
@@ -693,8 +695,7 @@ public class DeviceActivity extends Activity
       case KeyEvent.KEYCODE_SEARCH:
         return onSearchRequested();
       case KeyEvent.KEYCODE_MENU:   // HARDWRAE MENU (82)
-        String help_page = getResources().getString( R.string.DeviceActivity );
-        if ( help_page != null ) UserManualActivity.showHelpPage( this, help_page );
+        UserManualActivity.showHelpPage( this, getResources().getString( HELP_PAGE ) );
         return true;
       // case KeyEvent.KEYCODE_VOLUME_UP:   // (24)
       // case KeyEvent.KEYCODE_VOLUME_DOWN: // (25)
@@ -762,7 +763,7 @@ public class DeviceActivity extends Activity
       intent.putExtra( TopoDroidPreferences.PREF_CATEGORY, TopoDroidPreferences.PREF_CATEGORY_DEVICE );
       startActivity( intent );
     } else if ( p++ == pos ) { // HELP
-      (new HelpDialog(this, izons, menus, help_icons, help_menus, mNrButton1, help_menus.length ) ).show();
+      new HelpDialog(this, izons, menus, help_icons, help_menus, mNrButton1, help_menus.length, getResources().getString( HELP_PAGE ) ).show();
     // } else if ( TDLevel.overTester && p++ == pos ) { // CALIB_RESET
     //   doCalibReset();
     }

--- a/src/com/topodroid/DistoX/DrawingWindow.java
+++ b/src/com/topodroid/DistoX/DrawingWindow.java
@@ -259,6 +259,8 @@ public class DrawingWindow extends ItemDrawer
                         R.string.help_help
                       };
 
+  private static final int HELP_PAGE = R.string.DrawingWindow;
+
   private final static int DISMISS_NONE   = 0;
   private final static int DISMISS_EDIT   = 1;
   private final static int DISMISS_FILTER = 2;
@@ -4810,8 +4812,7 @@ public class DrawingWindow extends ItemDrawer
       case KeyEvent.KEYCODE_SEARCH:
         return onSearchRequested();
       case KeyEvent.KEYCODE_MENU:   // HARDWRAE MENU (82)
-        String help_page = getResources().getString( R.string.DrawingWindow );
-        if ( help_page != null ) UserManualActivity.showHelpPage( mActivity, help_page );
+        UserManualActivity.showHelpPage( mActivity, getResources().getString( HELP_PAGE ));
         return true;
       case KeyEvent.KEYCODE_VOLUME_UP:   // (24)
       case KeyEvent.KEYCODE_VOLUME_DOWN: // (25)
@@ -4970,7 +4971,7 @@ public class DrawingWindow extends ItemDrawer
         // 1 for select-tool
         int nn = 1 + NR_BUTTON1 + NR_BUTTON2 - 3 + NR_BUTTON5 - 5 + ( TDLevel.overBasic? mNrButton3 - 3: 0 );
         // Log.v("DistoX", "Help menu, nn " + nn );
-        (new HelpDialog(mActivity, izons, menus, help_icons, help_menus, nn, help_menus.length ) ).show();
+        new HelpDialog(mActivity, izons, menus, help_icons, help_menus, nn, help_menus.length, getResources().getString( HELP_PAGE ) ).show();
       }
   }
 

--- a/src/com/topodroid/DistoX/GMActivity.java
+++ b/src/com/topodroid/DistoX/GMActivity.java
@@ -138,6 +138,8 @@ public class GMActivity extends Activity
                         R.string.help_help
                       };
 
+  private static final int HELP_PAGE = R.string.GMActivity;
+
   static int mNrButton1 = 0;
   private Button[]     mButton1;
   HorizontalListView   mListView;
@@ -1082,9 +1084,7 @@ public class GMActivity extends Activity
       case KeyEvent.KEYCODE_SEARCH:
         return onSearchRequested();
       case KeyEvent.KEYCODE_MENU:   // HARDWRAE MENU (82)
-        String help_page = getResources().getString( R.string.GMActivity );
-        // if ( help_page != null )
-             UserManualActivity.showHelpPage( this, help_page );
+        UserManualActivity.showHelpPage( this, getResources().getString( HELP_PAGE ));
         return true;
       // case KeyEvent.KEYCODE_VOLUME_UP:   // (24)
       // case KeyEvent.KEYCODE_VOLUME_DOWN: // (25)
@@ -1149,7 +1149,7 @@ public class GMActivity extends Activity
       intent.putExtra( TopoDroidPreferences.PREF_CATEGORY, TopoDroidPreferences.PREF_CATEGORY_CALIB );
       startActivity( intent );
     } else if ( p++ == pos ) { // HELP
-      (new HelpDialog(this, izons, menus, help_icons, help_menus, mNrButton1, menus.length ) ).show();
+      new HelpDialog(this, izons, menus, help_icons, help_menus, mNrButton1, menus.length, getResources().getString( HELP_PAGE ) ).show();
     }
   }
 

--- a/src/com/topodroid/DistoX/HelpDialog.java
+++ b/src/com/topodroid/DistoX/HelpDialog.java
@@ -49,11 +49,12 @@ class HelpDialog extends Dialog
   private int mMenuTexts[];
   private int mNr0;
   private int mNr1;
+  private String mPage;
 
   private Button mBtnManual;
 
   // TODO list of help entries
-  HelpDialog( Context context, int icons[], int menus[], int texts1[], int texts2[], int n0, int n1 )
+  HelpDialog( Context context, int icons[], int menus[], int texts1[], int texts2[], int n0, int n1, String page )
   {
     super( context );
     mContext = context;
@@ -107,7 +108,7 @@ class HelpDialog extends Dialog
   public void onClick( View v ) 
   {
     dismiss();
-    mContext.startActivity( new Intent( Intent.ACTION_VIEW ).setClass( mContext, UserManualActivity.class ) );
+    UserManualActivity.showHelpPage( mContext, mPage );
   }
 
 }

--- a/src/com/topodroid/DistoX/MainWindow.java
+++ b/src/com/topodroid/DistoX/MainWindow.java
@@ -154,6 +154,8 @@ public class MainWindow extends Activity
                           R.string.help_help
                         };
 
+  private static final int HELP_PAGE = R.string.MainWindow;
+
   // -------------------------------------------------------------
   private boolean say_no_survey = true;
   private boolean say_not_enabled = true; // whether to say that BT is not enabled
@@ -430,7 +432,7 @@ public class MainWindow extends Activity
               startActivity( intent );
             } else { 
               if ( p++ == pos ) { // HELP
-                (new HelpDialog(mActivity, izons, menus, help_icons, help_menus, mNrButton1, menus.length ) ).show();
+                new HelpDialog(mActivity, izons, menus, help_icons, help_menus, mNrButton1, menus.length, getResources().getString( HELP_PAGE )).show();
               }
             }
           }
@@ -792,8 +794,7 @@ public class MainWindow extends Activity
       case KeyEvent.KEYCODE_SEARCH:
         return onSearchRequested();
       case KeyEvent.KEYCODE_MENU:   // HARDWRAE MENU (82)
-        String help_page = getResources().getString( R.string.MainWindow );
-        if ( help_page != null ) UserManualActivity.showHelpPage( mActivity, help_page );
+        UserManualActivity.showHelpPage( mActivity, getResources().getString( HELP_PAGE ));
         return true;
       // case KeyEvent.KEYCODE_VOLUME_UP:   // (24)
       // case KeyEvent.KEYCODE_VOLUME_DOWN: // (25)

--- a/src/com/topodroid/DistoX/OverviewWindow.java
+++ b/src/com/topodroid/DistoX/OverviewWindow.java
@@ -99,6 +99,9 @@ public class OverviewWindow extends ItemDrawer
                         R.string.help_prefs,
                         R.string.help_help
                       };
+
+  private static final int HELP_PAGE = R.string.OverviewWindow;
+
   // FIXME_OVER BitmapDrawable mBMextend;
   // FIXME_OVER BitmapDrawable mBMplan;
   BitmapDrawable mBMselect;
@@ -1061,8 +1064,7 @@ public class OverviewWindow extends ItemDrawer
       case KeyEvent.KEYCODE_SEARCH:
         return onSearchRequested();
       case KeyEvent.KEYCODE_MENU:   // HARDWRAE MENU (82)
-        String help_page = getResources().getString( R.string.OverviewWindow );
-        if ( help_page != null ) UserManualActivity.showHelpPage( mActivity, help_page );
+        UserManualActivity.showHelpPage( mActivity, getResources().getString( HELP_PAGE ));
         return true;
       // case KeyEvent.KEYCODE_VOLUME_UP:   // (24)
       // case KeyEvent.KEYCODE_VOLUME_DOWN: // (25)
@@ -1105,7 +1107,7 @@ public class OverviewWindow extends ItemDrawer
       intent.putExtra( TopoDroidPreferences.PREF_CATEGORY, TopoDroidPreferences.PREF_CATEGORY_PLOT );
       mActivity.startActivity( intent );
     } else if ( p++ == pos ) { // HELP
-      (new HelpDialog(mActivity, izons, menus, help_icons, help_menus, mNrButton1, menus.length ) ).show();
+      new HelpDialog(mActivity, izons, menus, help_icons, help_menus, mNrButton1, menus.length, getResources().getString( HELP_PAGE ) ).show();
     }
   }
 

--- a/src/com/topodroid/DistoX/ShotWindow.java
+++ b/src/com/topodroid/DistoX/ShotWindow.java
@@ -174,6 +174,8 @@ public class ShotWindow extends Activity
                           R.string.help_help
                       };
 
+  private static final int HELP_PAGE = R.string.ShotWindow;
+
   private TopoDroidApp   mApp;
   private Activity       mActivity;
   private DataDownloader mDataDownloader;
@@ -642,7 +644,7 @@ public class ShotWindow extends Activity
       mActivity.startActivity( intent );
     } else if ( p++ == pos ) { // HELP
       // int nn = mNrButton1; //  + ( TDLevel.overNormal ?  mNrButton2 : 0 );
-      (new HelpDialog(mActivity, izons, menus, help_icons, help_menus, mNrButton1, menus.length ) ).show();
+      new HelpDialog(mActivity, izons, menus, help_icons, help_menus, mNrButton1, menus.length, getResources().getString( HELP_PAGE ) ).show();
     }
   }
 
@@ -1647,8 +1649,7 @@ public class ShotWindow extends Activity
       case KeyEvent.KEYCODE_SEARCH:
         return onSearchRequested();
       case KeyEvent.KEYCODE_MENU:   // HARDWRAE MENU (82)
-        String help_page = getResources().getString( R.string.ShotWindow );
-        if ( help_page != null ) UserManualActivity.showHelpPage( mActivity, help_page );
+        UserManualActivity.showHelpPage( mActivity, getResources().getString( HELP_PAGE ));
         return true;
       // case KeyEvent.KEYCODE_VOLUME_UP:   // (24)
       // case KeyEvent.KEYCODE_VOLUME_DOWN: // (25)

--- a/src/com/topodroid/DistoX/SketchWindow.java
+++ b/src/com/topodroid/DistoX/SketchWindow.java
@@ -252,6 +252,8 @@ public class SketchWindow extends ItemDrawer
                         R.string.help_help
                       };
 
+  private static final int HELP_PAGE = R.string.SketchWindow;
+
   private int mSelectMode = Drawing.FILTER_ALL;
   private int mSelectScale = 0;
 
@@ -2055,7 +2057,7 @@ public class SketchWindow extends ItemDrawer
       mActivity.startActivity( optionsIntent );
     } else if ( p++ == pos ) { // HELP
       int nn = mNrButton1 + mNrButton2 - GREEN_BTN + /* mNrButton3 - GREEN_BTN */ + mNrButton4 - GREEN_BTN;
-      (new HelpDialog(mActivity, izons, menus, help_icons, help_menus, nn, menus.length ) ).show();
+      new HelpDialog(mActivity, izons, menus, help_icons, help_menus, nn, menus.length, getResources().getString( HELP_PAGE ) ).show();
     }
   }
 
@@ -2213,8 +2215,7 @@ public class SketchWindow extends ItemDrawer
       case KeyEvent.KEYCODE_SEARCH:
         return onSearchRequested();
       case KeyEvent.KEYCODE_MENU:   // HARDWRAE MENU (82)
-        String help_page = getResources().getString( R.string.SketchWindow );
-        if ( help_page != null ) UserManualActivity.showHelpPage( mActivity, help_page );
+        UserManualActivity.showHelpPage( mActivity, getResources().getString( HELP_PAGE ));
         return true;
       // case KeyEvent.KEYCODE_VOLUME_UP:   // (24)
       // case KeyEvent.KEYCODE_VOLUME_DOWN: // (25)

--- a/src/com/topodroid/DistoX/SurveyWindow.java
+++ b/src/com/topodroid/DistoX/SurveyWindow.java
@@ -102,6 +102,9 @@ public class SurveyWindow extends Activity
                         R.string.help_prefs,
                         R.string.help_help
                       };
+
+  private static final int HELP_PAGE = R.string.SurveyWindow;
+
   // private static int icons00[];
 
   // private ShotWindow mParent;
@@ -490,8 +493,7 @@ public class SurveyWindow extends Activity
       case KeyEvent.KEYCODE_SEARCH:
         return onSearchRequested();
       case KeyEvent.KEYCODE_MENU:   // HARDWRAE MENU (82)
-        String help_page = getResources().getString( R.string.SurveyWindow );
-        if ( help_page != null ) UserManualActivity.showHelpPage( mActivity, help_page );
+        UserManualActivity.showHelpPage( mActivity, getResources().getString( HELP_PAGE ));
         return true;
       // case KeyEvent.KEYCODE_VOLUME_UP:   // (24)
       // case KeyEvent.KEYCODE_VOLUME_DOWN: // (25)
@@ -556,7 +558,7 @@ public class SurveyWindow extends Activity
       intent.putExtra( TopoDroidPreferences.PREF_CATEGORY, TopoDroidPreferences.PREF_CATEGORY_SURVEY );
       mActivity.startActivity( intent );
     } else if ( p++ == pos ) { // HELP
-      (new HelpDialog(mActivity, izons, menus, help_icons, help_menus, mNrButton1, menus.length ) ).show();
+      new HelpDialog(mActivity, izons, menus, help_icons, help_menus, mNrButton1, menus.length, getResources().getString( HELP_PAGE ) ).show();
     }
     // updateDisplay();
   }


### PR DESCRIPTION
I've been trying your app and think is a little bit annoying that every time I opened the man pages it always directed me to the main page not the one corresponding to the view I was using. That is what inspired me to make this pull request. After navigating through the code I saw that opening the correct page does work but only when you use KEYCODE_MENU (btw menu button was removed in Android 3.0 Honeycomb) but not when using settings actions. Anyways, what I've done is unify the behaviour for both methods.