### PR TITLE
Fix Survex export declination handling

### DIFF
--- a/src/com/topodroid/DistoX/TDExporter.java
+++ b/src/com/topodroid/DistoX/TDExporter.java
@@ -1172,7 +1172,7 @@ class TDExporter
    *    *begin survey_name
    *      *units tape feet|metres
    *      *units compass clino grads|degrees
-   *      *calibrate declination ...
+   *      *declination ... ; optional
    *      *date yyyy.mm.dd
    *      ; *fix station long lat alt
    *      ; *team "teams"
@@ -1282,7 +1282,15 @@ class TDExporter
       writeSurvexLine(pw, "  *units tape " + uls );
       writeSurvexLine(pw, "  *units compass " + uas );
       writeSurvexLine(pw, "  *units clino " + uas );
-      pw.format(Locale.US, "  *calibrate declination %.2f", info.declination ); writeSurvexEOL(pw);
+      // Don't specify a declination unless one was actually specified, as that
+      // breaks datasets using "*declination auto <coordinates>" at a higher
+      // level, which is the recommended way to handle declinations in Survex
+      // nowadays.
+      if (info.declination != 0.0) {
+        // *declination with an angle needs Survex 1.2.22 (released 2015-08-17).
+        // FIXME: Really should distinguish "unset" vs "set to 0.0".
+        pw.format(Locale.US, "  *declination %.2f", info.declination ); writeSurvexEOL(pw);
+      }
       if ( ! TDSetting.mSurvexSplay ) {
         writeSurvexLine( pw, "  *alias station - .." );
       }


### PR DESCRIPTION
*calibrate declination takes a value with the opposite sign to the
conventional declination, which means that currently Topodroid's Survex
exports all have the wrong declination (unless it's exactly 0° or 180°).

Instead use the modern *declination command which takes a declination
with the expected sign (requires Survex 1.2.22 released 2015-08-17
so not an onerous requirement).

Omit the *declination entirely when it's not been specified.  The
recommended way to set the declination in Survex nowadays is to use
"*declination auto <coords>" in a higher level survey, which calculates
the declination from the latest IGRF model, and also handles grid
convergence.  It's really annoying that Topodroid insists on inserting a
bogus explicit declination of 0.00, which the user has to manually
remove (and we've found often forgets to, and then somebody else has to
go through and remove them later).

This patch makes the assumption that a declination of 0 means unset,
which isn't ideal.  It would be better if "declination is set" was
tracked explicitly in the "info" object, but that's beyond what I can
sensibly supply a patch for without an Android build environment.