### PR TITLE
strings_update.pl using libxml

### DIFF
--- a/utils/strings_update.pl
+++ b/utils/strings_update.pl
@@ -111,7 +111,7 @@ sub analyze_xml_file ($filename, $dom, $names_ref) {
   my @empty_named_elements;
   my $xml_ok = 1;
 
-  for my $named_element ($dom->findnodes('//*[@name]')) {
+  for my $named_element ($dom->findnodes('/resources/*[@name]')) {
     # print "\$named_element em analyze_xml_file: '" . Dumper($named_element) . "'\n";
     my $name = trim($named_element->getAttribute('name'));
 
@@ -129,7 +129,7 @@ sub analyze_xml_file ($filename, $dom, $names_ref) {
     # print "'$name': '" . $named_element->textContent() . "'\n";
   }
 
-  for my $comment ($dom->findnodes('//comment()')) {
+  for my $comment ($dom->findnodes('/resources/comment()')) {
     # print "\$comment em analyze_xml_file: '" . Dumper($comment) . "'\n";
     my $name = parse_comment_name($comment->textContent());
     my $tag = parse_comment_tag($comment);

--- a/utils/strings_update.pl
+++ b/utils/strings_update.pl
@@ -186,7 +186,15 @@ sub get_comment_content_without_tag($element) {
 }
 
 sub get_element_without_limiters($element) {
-  my $content = $element->toString();
+  # Removing $element comment childs before getting $element content as string
+  # as a comment ending inside our new commment ends the comment prematurely.
+  for my $child ($element->childNodes()) {
+    if ($child->nodeType == XML_COMMENT_NODE) {
+      $child->unbindNode();
+    }
+  }
+
+  my $content = $element->toString(2);
 
   # print "\$content pré em get_element_without_limiters: '$content'\n";
   $content =~ s/^\<\s*//;

--- a/utils/strings_update.pl
+++ b/utils/strings_update.pl
@@ -255,6 +255,10 @@ for my $element ($en_dom->documentElement()->childNodes()) {
     }
   }
   else {
+    if ($element->nodeType == XML_COMMENT_NODE) {
+      next;
+    }
+
     my $content = ' TODO ' . get_element_without_limiters($element) . ' ';
     my $new_comment = XML::LibXML::Comment->new($content);
     $element->replaceNode($new_comment);

--- a/utils/strings_update.pl
+++ b/utils/strings_update.pl
@@ -55,7 +55,7 @@ sub parse_comment_name ($content) {
 
   if ( $content =~ /name="/ ) {
     $name = $content;
-    $name =~ s/^.*name="//;
+    $name =~ s/^.*?name="//;
     $name =~ s/".*$//;
     $name = trim($name);
   }

--- a/utils/strings_update.pl
+++ b/utils/strings_update.pl
@@ -225,7 +225,7 @@ for my $element ($en_dom->documentElement()->childNodes()) {
   # print "\$name: '$name'\n";
   if (($element->nodeType != XML_COMMENT_NODE)
     && $element->hasAttribute('translatable')
-    && ($element->getAttribute('translatable') == 'false')) {
+    && ($element->getAttribute('translatable') eq 'false')) {
     $element->unbindNode();
     next;
   }

--- a/utils/strings_update.pl
+++ b/utils/strings_update.pl
@@ -221,14 +221,15 @@ if ($@) {
 analyze_xml_file($en_filename, $en_dom, \%en_names);
 
 for my $element ($en_dom->documentElement()->childNodes()) {
-  my $name = get_node_name($element);
-  # print "\$name: '$name'\n";
   if (($element->nodeType != XML_COMMENT_NODE)
     && $element->hasAttribute('translatable')
     && ($element->getAttribute('translatable') eq 'false')) {
     $element->unbindNode();
     next;
   }
+
+  my $name = get_node_name($element);
+  # print "\$name: '$name'\n";
 
   if ($name eq '') {
     next;

--- a/utils/strings_update.pl
+++ b/utils/strings_update.pl
@@ -79,7 +79,7 @@ sub add_named_element ($name, $element_ref) {
       $xx_duplicated_names{$name} .= $element_ref;
     }
     else {
-      $xx_duplicated_names{$name} = [$element_ref];
+      $xx_duplicated_names{$name} = [$xx_names{$name}, $element_ref];
     }
   }
   else {


### PR DESCRIPTION
New version of strings_update.pl using Perl XML::LibXML module.

It's working with strings.xml, plurals.xml and array.xml.

It processes all direct childs of the resources root element.

It produces a copy of the EN file with:

For entries that have already been translated:
1. The contents of the translated version applied over the original english version for non comment elements in EN;
2. The contents of the translated version in a comment with the same tag as the original english version for comment elements in EN;

For entries that have not been translated:
1. A copy of the original english version of comments;
2. A copy of the original english version of non comment elements transformed to a comment with a TODO tag.

To make this work a few requirements are applied:
1. There should not be entries with duplicated names even if only one of them is not a comment. This is checked both on the EN file and on the XX file;
2. Comments inside parent entries that will be tagged as TODO in the NEW version are discarded to not mess the TODO comment ending (like the comments currently defined in <string-array name="bricMode"> inside array.xml).
