### PR TITLE
Add share functionality for KML and Therion exports

### DIFF
--- a/res/layout/export_dialog_shot.xml
+++ b/res/layout/export_dialog_shot.xml
@@ -221,9 +221,14 @@
       android:text="@string/export_uncommented_maps"
       />
     <CheckBox android:id="@+id/therion_lrud"
-      android:layout_width="match_parent" 
+      android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:text="@string/export_lrud"
+      />
+    <CheckBox android:id="@+id/therion_share"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:text="@string/export_share"
       />
   </LinearLayout>
 
@@ -389,9 +394,14 @@
       android:text="@string/export_splays"
       />
     <CheckBox android:id="@+id/kml_stations"
-      android:layout_width="match_parent" 
+      android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:text="@string/export_stations"
+      />
+    <CheckBox android:id="@+id/kml_share"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:text="@string/export_share"
       />
   </LinearLayout>
 

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -756,6 +756,7 @@ On Android-11+ storage access must be granted to TopoDroid.\nYou can do this wit
     <string name="zip_saved">Saved zip archive</string>
     <string name="zip_failed">Failed survey-zip</string>
     <string name="zip_share_failed">Unable to share zip-archive</string>
+    <string name="file_share_failed">Unable to share file</string>
     <string name="unzip_fail">Failed survey-unzip</string>
     <string name="unzip_fail_sqlite">Failed SQL: delete survey and retry</string>
     <string name="unzip_fail_survey">Failed: survey name mismatch</string>

--- a/src/com/topodroid/TDX/ExportDialogShot.java
+++ b/src/com/topodroid/TDX/ExportDialogShot.java
@@ -444,6 +444,7 @@ public class ExportDialogShot extends MyDialog
           TDSetting.mTherionMaps = ((CheckBox) findViewById( R.id.therion_maps )).isChecked();
           TDSetting.mTherionUncommentedMaps = ((CheckBox) findViewById( R.id.therion_uncommented_maps )).isChecked();
           TDSetting.mSurvexLRUD  = ((CheckBox) findViewById( R.id.therion_lrud )).isChecked();
+          TDSetting.mThShare = ((CheckBox) findViewById( R.id.therion_share )).isChecked();
         }
         break;
       // case 7: // Topo
@@ -502,6 +503,7 @@ public class ExportDialogShot extends MyDialog
         {
           TDSetting.mKmlSplays = ((CheckBox) findViewById( R.id.kml_splays )).isChecked();
           TDSetting.mKmlStations = ((CheckBox) findViewById( R.id.kml_stations )).isChecked();
+          TDSetting.mKmlShare = ((CheckBox) findViewById( R.id.kml_share )).isChecked();
         }
         break;
       case TDConst.SURVEY_POS_SHAPEFILE: // Shapefile
@@ -545,6 +547,7 @@ public class ExportDialogShot extends MyDialog
     ((CheckBox) findViewById( R.id.therion_maps )).setChecked( TDSetting.mTherionMaps );
     ((CheckBox) findViewById( R.id.therion_uncommented_maps )).setChecked( TDSetting.mTherionUncommentedMaps );
     ((CheckBox) findViewById( R.id.therion_lrud )).setChecked( TDSetting.mSurvexLRUD );
+    ((CheckBox) findViewById( R.id.therion_share )).setChecked( TDSetting.mThShare );
     if ( mDiving ) {
       ((CheckBox) findViewById( R.id.vtopo_trox )).setVisibility( View.GONE );
     } else {
@@ -568,6 +571,7 @@ public class ExportDialogShot extends MyDialog
 
     ((CheckBox) findViewById( R.id.kml_splays )).setChecked( TDSetting.mKmlSplays );
     ((CheckBox) findViewById( R.id.kml_stations )).setChecked( TDSetting.mKmlStations );
+    ((CheckBox) findViewById( R.id.kml_share )).setChecked( TDSetting.mKmlShare );
 
     ((CheckBox) findViewById( R.id.shp_splays )).setChecked( TDSetting.mKmlSplays );
     ((CheckBox) findViewById( R.id.shp_stations )).setChecked( TDSetting.mKmlStations );

--- a/src/com/topodroid/TDX/TopoDroidApp.java
+++ b/src/com/topodroid/TDX/TopoDroidApp.java
@@ -3296,7 +3296,7 @@ public class TopoDroidApp extends Application
       Uri uri = Uri.fromFile( new File( TDPath.getOutFile( filename ) ) );
       if ( uri != null ) {
         // TDLog.v("EXPORT " + filename + " info " + export_info.index + " " + export_info.name );
-        (new SaveDataFileTask( uri, format, TDInstance.sid, survey_info, mData, TDInstance.survey, TDInstance.getDeviceA(), export_info, toast )).execute();
+        (new SaveDataFileTask( this, uri, format, TDInstance.sid, survey_info, mData, TDInstance.survey, TDInstance.getDeviceA(), export_info, toast )).execute();
         return true;
       }
     }
@@ -3323,6 +3323,30 @@ public class TopoDroidApp extends Application
       // mSurveyWindow.startActivity( Intent.createChooser( intent, "chooser title" ) );
     } catch ( ActivityNotFoundException e ) {
       TDToast.makeWarn( R.string.zip_share_failed );
+    }
+  }
+
+  /** share a file (KML, TH, etc.)
+   * @param filename   the filename (relative, e.g., "survey.kml")
+   * @param mimeType   the MIME type for the file
+   */
+  void shareFile( String filename, String mimeType )
+  {
+    String filepath = TDPath.getOutFile( filename );
+    TDLog.v("Share file " + filepath );
+    Uri uri = MyFileProvider.fileToUri( this, TDFile.getFile( filepath ) );
+
+    Intent intent = new Intent( );
+    intent.setAction( Intent.ACTION_SEND );
+    intent.putExtra( Intent.EXTRA_STREAM, uri );
+    intent.setType( mimeType );
+    intent.addFlags( Intent.FLAG_GRANT_READ_URI_PERMISSION );
+    try {
+      if ( mSurveyWindow != null ) {
+        mSurveyWindow.startActivity( intent );
+      }
+    } catch ( ActivityNotFoundException e ) {
+      TDToast.makeWarn( R.string.file_share_failed );
     }
   }
 

--- a/src/com/topodroid/prefs/TDSetting.java
+++ b/src/com/topodroid/prefs/TDSetting.java
@@ -278,6 +278,8 @@ public class TDSetting
   public static boolean mZipShare             = false;  // whether to share exported zip
   public static boolean mZipShareCategory     = false;  // DISTOX_ZIP_SHARE_CATEGORY
   public static boolean mZipOverwrite         = true;   // whether to overwrite exported zip
+  public static boolean mKmlShare             = false;  // whether to share exported KML
+  public static boolean mThShare              = false;  // whether to share exported Therion
 
   // ------------ THERION
   public static final float THERION_SCALE = 196.8503937f; // 200 * 39.3700787402 / 40;


### PR DESCRIPTION
## Summary
- Add option to share exported KML and TH files directly after export, similar to the existing ZIP share feature
- Add share checkbox to KML and Therion export dialogs
- Add `shareFile()` method in TopoDroidApp for generic file sharing

## Changes
- `res/layout/export_dialog_shot.xml` - Added share checkboxes for KML and Therion layouts
- `res/values/strings.xml` - Added `file_share_failed` string resource
- `src/com/topodroid/TDX/ExportDialogShot.java` - Handle share checkbox state
- `src/com/topodroid/TDX/SaveDataFileTask.java` - Added sharing logic after export
- `src/com/topodroid/TDX/TopoDroidApp.java` - Added `shareFile()` method
- `src/com/topodroid/prefs/TDSetting.java` - Added `mKmlShare` and `mThShare` settings

## Test plan
- [ ] Export survey as KML with "Share" checkbox enabled
- [ ] Verify Android share dialog appears after export
- [ ] Export survey as Therion (.th) with "Share" checkbox enabled
- [ ] Verify Android share dialog appears after export
- [ ] Test with share checkbox disabled (should just save without sharing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)