### PR TITLE
Add JedEye BLE device support

### DIFF
--- a/src/com/topodroid/TDX/DeviceActivity.java
+++ b/src/com/topodroid/TDX/DeviceActivity.java
@@ -377,6 +377,9 @@ public class DeviceActivity extends Activity
         } else if ( Device.isCavwayX1( model ) ) {
           mApp_mDData.updateDeviceModel( device.getAddress(), Device.NAME_CAVWAY + "0000" );
           device.mType = model;
+        } else if ( Device.isJedeye( model ) ) {
+          mApp_mDData.updateDeviceModel( device.getAddress(), Device.NAME_JEDEYE + "0000" );
+          device.mType = model;
         }
       }
       updateList( false );
@@ -738,6 +741,9 @@ public class DeviceActivity extends Activity
           mApp_mDData.insertDevice( address, bt_name, name, null );
           dev = mApp_mDData.getDevice( address );
         } else if ( Device.isDiscoX( bt_name ) ) { // discox
+          mApp_mDData.insertDevice( address, bt_name, name, null );
+          dev = mApp_mDData.getDevice( address );
+        } else if ( Device.isJedeye( bt_name ) ) { // JedEye
           mApp_mDData.insertDevice( address, bt_name, name, null );
           dev = mApp_mDData.getDevice( address );
         }

--- a/src/com/topodroid/TDX/TDInstance.java
+++ b/src/com/topodroid/TDX/TDInstance.java
@@ -105,6 +105,10 @@ public class TDInstance
    */
   public static boolean isDeviceDiscoX() { return deviceA != null && deviceA.isDiscoX(); }
 
+  /** @return true if the primary device is set and is a JedEye
+   */
+  public static boolean isDeviceJedeye() { return deviceA != null && deviceA.isJedeye(); }
+
   /** @return true if the primary device is set and is of type BRIC (BRIC4 or BRIC5)
    */
   public static boolean isDeviceBric()   { return deviceA != null && deviceA.isBric(); }
@@ -189,7 +193,7 @@ public class TDInstance
   /** @return true if the primary device is LE
    * SIWEI_TIAN
    */
-  static boolean isDeviceBLE()    { return deviceA != null && ( deviceA.isBric() || deviceA.isSap() || deviceA.isDistoXBLE() || deviceA.isCavway() ); }
+  static boolean isDeviceBLE()    { return deviceA != null && ( deviceA.isBric() || deviceA.isSap() || deviceA.isDistoXBLE() || deviceA.isCavway() || deviceA.isJedeye() ); }
 
   public static boolean isDeviceCavway()   { return deviceA != null && deviceA.isCavway(); }
 
@@ -199,7 +203,7 @@ public class TDInstance
    * @param device   bluetooth device
    * SIWEI_TIAN
    */
-  private static boolean isDeviceBLE( Device device )    { return device != null && ( device.isBric() || device.isSap() || device.isDistoXBLE() || device.isCavway() ); }
+  private static boolean isDeviceBLE( Device device )    { return device != null && ( device.isBric() || device.isSap() || device.isDistoXBLE() || device.isCavway() || device.isJedeye() ); }
 
   /** @return true if the connection is set in continuous mode
    */

--- a/src/com/topodroid/TDX/TopoDroidApp.java
+++ b/src/com/topodroid/TDX/TopoDroidApp.java
@@ -50,6 +50,7 @@ import com.topodroid.dev.distox2.DeviceX310Details;
 import com.topodroid.dev.cavway.CavwaySyncDateTimeTask;
 import com.topodroid.dev.sap.SapComm;
 import com.topodroid.dev.discox.DiscoXComm;
+import com.topodroid.dev.jedeye.JedeyeComm;
 import com.topodroid.dev.bric.BricComm;
 import com.topodroid.dev.bric.BricInfoDialog;
 import com.topodroid.dev.PairingRequest; // FIXME DROP_PAIRING
@@ -923,6 +924,10 @@ public class TopoDroidApp extends Application
         String address = TDInstance.deviceAddress();
         BluetoothDevice bt_device = TDInstance.getBleDevice();
         mComm = new CavwayComm( this,this, address, bt_device );
+      } else if ( TDInstance.isDeviceJedeye() ) {
+        String address = TDInstance.deviceAddress();
+        BluetoothDevice bt_device = TDInstance.getBleDevice();
+        mComm = new JedeyeComm( this, address, bt_device );
       }
     // }
   }
@@ -1896,6 +1901,8 @@ public class TopoDroidApp extends Application
           mComm = new SapComm( this, address, bt_device, 6 ); 
         } else if ( TDInstance.isDeviceBric() ) {
           mComm = new BricComm( this, this, address, bt_device );
+        } else if ( TDInstance.isDeviceJedeye() ) {
+          mComm = new JedeyeComm( this, address, bt_device );
         }
       } else { // addr, null, null
         // boolean create = Device.isBle( TDInstance.deviceType() );

--- a/src/com/topodroid/dev/Device.java
+++ b/src/com/topodroid/dev/Device.java
@@ -38,14 +38,16 @@ public class Device
   public final static String NAME_SAP6_2    = "SAP_";
   public final static String NAME_CAVWAY    = "CavwayX1-";
   public final static String NAME_DISCOX    = "discox_";
-  
+  public final static String NAME_JEDEYE    = "JedEye_";
+
   // supported models and their common names
   public final static String[] mModels = {
     NAME_DISTOX1, NAME_DISTOX2, NAME_DISTOXBLE,
     NAME_BRIC4, NAME_BRIC5, NAME_BRIC5_2,
     NAME_SAP5, NAME_SAP5_2, NAME_SAP6, NAME_SAP6_2,
     NAME_CAVWAY,
-    NAME_DISCOX };
+    NAME_DISCOX,
+    NAME_JEDEYE };
 
   /** device presentation names, for the user interface
    */
@@ -54,7 +56,8 @@ public class Device
     "BRIC 4", "BRIC 5", "BRIC 5",
     "SAP 5",  "SAP 5",  "SAP 6",  "SAP 6",
     "Cavway X1",
-    "discox" };
+    "discox",
+    "JedEye" };
 
   /** these "advertised names" are used to set the device through a setting
    * BT aliases are saved in device.sqlite
@@ -64,7 +67,8 @@ public class Device
     "BRIC 4", "BRIC 5", null,
     "SAP 5",  null, "SAP 6", null,
     "Cavway X1",
-    "discox" };
+    "discox",
+    "JedEye" };
 
   /** @return true if the BT name is known
    * @param name   device BT advertised name
@@ -76,11 +80,12 @@ public class Device
     if ( name.startsWith( "discox" ) ) return true;
     if ( name.startsWith( "BRIC" ) )   return true;
     if ( name.startsWith( "SAP" ) )    return true;
+    if ( name.startsWith( "JedEye" ) ) return true;
     return false;
   }
 
   // supported BLE models
-  final static String[] mBleModels = { NAME_DISTOXBLE, NAME_BRIC4, NAME_BRIC5, NAME_BRIC5_2, NAME_SAP5, NAME_SAP5_2, NAME_SAP6, NAME_SAP6_2, NAME_CAVWAY, NAME_DISCOX };
+  final static String[] mBleModels = { NAME_DISTOXBLE, NAME_BRIC4, NAME_BRIC5, NAME_BRIC5_2, NAME_SAP5, NAME_SAP5_2, NAME_SAP6, NAME_SAP6_2, NAME_CAVWAY, NAME_DISCOX, NAME_JEDEYE };
 
   // DistoX2 / SAP6 commands
   // commands
@@ -122,11 +127,12 @@ public class Device
   public final static int DISTO_BRIC5    =  9;
   public final static int DISTO_CAVWAYX1 = 10;
   public final static int DISTO_DISCOX   = 11;
+  public final static int DISTO_JEDEYE   = 12;
 
 
-  // SIWEI_TIAN                                       0          1         2          3          4       5       6        7            8       9        10      11
-  final static String[] typeString               = { "Unknown", "A3",     "X310",    "X000",    "BLEX", "SAP5", "BRIC4", "XBLE",      "SAP6", "BRIC5", "CVWY1", "discox" };
-  private final static String[] typeSimpleString = { "Unknown", "DistoX", "DistoX2", "DistoX0", "BleX", "Sap5", "Bric4", "DistoXBLE", "Sap6", "Bric5", "CVWY1", "discox" };
+  // SIWEI_TIAN                                       0          1         2          3          4       5       6        7            8       9        10       11        12
+  final static String[] typeString               = { "Unknown", "A3",     "X310",    "X000",    "BLEX", "SAP5", "BRIC4", "XBLE",      "SAP6", "BRIC5", "CVWY1", "discox", "JedEye" };
+  private final static String[] typeSimpleString = { "Unknown", "DistoX", "DistoX2", "DistoX0", "BleX", "Sap5", "Bric4", "DistoXBLE", "Sap6", "Bric5", "CVWY1", "discox", "JedEye" };
   
   /** @return the string concise name of the device type
    * @param type  device type (between 0 and 11)
@@ -165,14 +171,14 @@ public class Device
 
   /** @return true if the device is Bluetooth LE
    */
-  public boolean isBLE( ) { return mType == DISTO_XBLE || mType == DISTO_BRIC4 || mType == DISTO_BRIC5 
-                                || mType == DISTO_SAP5 || mType == DISTO_SAP6  || mType == DISTO_CAVWAYX1 || mType == DISTO_DISCOX; } // SIWEI_TIAN
+  public boolean isBLE( ) { return mType == DISTO_XBLE || mType == DISTO_BRIC4 || mType == DISTO_BRIC5
+                                || mType == DISTO_SAP5 || mType == DISTO_SAP6  || mType == DISTO_CAVWAYX1 || mType == DISTO_DISCOX || mType == DISTO_JEDEYE; } // SIWEI_TIAN
 
   /** @return true if the device tyeo is Bluetooth LE
    * @param type   device type
    */
   public static boolean isBle( int type ) { return type == DISTO_XBLE || type == DISTO_BRIC4 || type == DISTO_BRIC5
-                                               ||  type == DISTO_SAP5 || type == DISTO_SAP6  || type == DISTO_CAVWAYX1 || type == DISTO_DISCOX; } // SIWEI_TIAN
+                                               ||  type == DISTO_SAP5 || type == DISTO_SAP6  || type == DISTO_CAVWAYX1 || type == DISTO_DISCOX || type == DISTO_JEDEYE; } // SIWEI_TIAN
 
   public boolean isDistoX( )    { return mType == DISTO_X310  || mType == DISTO_A3; }
   public boolean isA3( )        { return mType == DISTO_A3; }
@@ -187,6 +193,7 @@ public class Device
   public boolean isCavway()     { return mType == DISTO_CAVWAYX1; }
   public boolean isCavwayX1()   { return mType == DISTO_CAVWAYX1; }
   public boolean isDiscoX()     { return mType == DISTO_DISCOX; }
+  public boolean isJedeye()     { return mType == DISTO_JEDEYE; }
 
   public static boolean isDistoX( int type )    { return type == DISTO_X310 || type == DISTO_A3; }
   public static boolean isA3( int type )        { return type == DISTO_A3; }
@@ -201,12 +208,14 @@ public class Device
   public static boolean isCavway( int type )    { return type == DISTO_CAVWAYX1; }
   public static boolean isCavwayX1( int type )  { return type == DISTO_CAVWAYX1; }
   public static boolean isDiscoX( int type )    { return type == DISTO_DISCOX; }
+  public static boolean isJedeye( int type )    { return type == DISTO_JEDEYE; }
 
   public static boolean isDistoX( String bt_name ) { return bt_name.startsWith("DistoX"); }
   public static boolean isSap( String bt_name )    { return bt_name.startsWith("Shetland") || bt_name.startsWith("SAP"); }
   public static boolean isBric( String bt_name )   { return bt_name.startsWith("BRIC"); }
   public static boolean isCavway( String bt_name ) { return bt_name.startsWith("Cavway"); }
   public static boolean isDiscoX( String bt_name ) { return bt_name.startsWith("discox"); }
+  public static boolean isJedeye( String bt_name ) { return bt_name.startsWith("JedEye"); }
 
   // SIWEI_TIAN
   // public boolean canSendCommand() { return mType == DISTO_X310 mType == DISTO_XBLE || mType == DISTO_BRIC4 || mType == DISTO_BRIC5 || mType == DISTO_SAP6; }
@@ -231,6 +240,7 @@ public class Device
     if ( bt_name.startsWith( NAME_BRIC5_2 ) )   return "BRIC5";
     if ( bt_name.startsWith( NAME_BRIC4 ) )     return "BRIC4";
     if ( bt_name.startsWith( NAME_DISCOX ) )    return "discox";
+    if ( bt_name.startsWith( NAME_JEDEYE ) )    return "JedEye";
     if ( bt_name.startsWith( NAME_SAP5 ) )      return "SAP5";
     if ( bt_name.startsWith( NAME_SAP5_2 ) )    return "SAP5";
     if ( bt_name.startsWith( NAME_SAP6 ) )      return "SAP6";
@@ -253,6 +263,7 @@ public class Device
     if ( bt_name.startsWith( NAME_DISTOXBLE ) ) return bt_name.replace( NAME_DISTOXBLE , "" );
     if ( bt_name.startsWith( NAME_CAVWAY ) )    return bt_name.replace( NAME_CAVWAY, "" );
     if ( bt_name.startsWith( NAME_DISCOX ) )    return bt_name.replace( NAME_DISCOX, "" );
+    if ( bt_name.startsWith( NAME_JEDEYE ) )    return bt_name.replace( NAME_JEDEYE, "" );
     // NAME_DISTOX1 left unchnaged
 
     if ( bt_name.startsWith( NAME_BRIC5 ) )   return bt_name.replace( NAME_BRIC5, "" );
@@ -292,6 +303,7 @@ public class Device
       if ( bt_name.equals( "A3" )    || bt_name.equals( NAME_DISTOX1 ) )       return DISTO_A3;
       if ( bt_name.startsWith( NAME_CAVWAY ) ) return DISTO_CAVWAYX1; // 10
       if ( bt_name.startsWith( NAME_DISCOX ) ) return DISTO_DISCOX;   // 11
+      if ( bt_name.startsWith( NAME_JEDEYE ) ) return DISTO_JEDEYE;   // 12
       // if ( bt_name.equals( "BLEX" ) ) return DISTO_BLEX; // FIXME BLE_5
       // if ( bt_name.equals( "X000" ) || bt_name.equals( "DistoX0" ) ) return DISTO_X000; // FIXME VirtualDistoX
     }
@@ -368,6 +380,7 @@ public class Device
     if ( name.startsWith( NAME_BRIC5_2 ) )   return name.replace( NAME_BRIC5_2, "");
     if ( name.startsWith( NAME_CAVWAY ) )    return name.replace( NAME_CAVWAY, "");
     if ( name.startsWith( NAME_DISCOX ) )    return name.replace( NAME_DISCOX, "");
+    if ( name.startsWith( NAME_JEDEYE ) )    return name.replace( NAME_JEDEYE, "");
     return name;
   }
 

--- a/src/com/topodroid/dev/jedeye/JedeyeComm.java
+++ b/src/com/topodroid/dev/jedeye/JedeyeComm.java
@@ -1,0 +1,64 @@
+/* @file JedeyeComm.java
+ *
+ * @author sebastien kister
+ * @date 2026
+ *
+ * @brief TopoDroid JedEye BLE communication
+ * --------------------------------------------------------
+ *  Copyright This software is distributed under GPL-3.0 or later
+ *  See the file COPYING.
+ * --------------------------------------------------------
+ *
+ * JedEye is wire-compatible with the SAP6 shot frame, so the BLE plumbing
+ * is inherited from SapComm. Only the GATT UUIDs differ.
+ */
+package com.topodroid.dev.jedeye;
+
+import com.topodroid.TDX.TopoDroidApp;
+import com.topodroid.dev.Device;
+import com.topodroid.dev.sap.SapComm;
+
+import android.content.Context;
+import android.bluetooth.BluetoothDevice;
+
+public class JedeyeComm extends SapComm
+{
+  /** cstr
+   * @param app        application
+   * @param address    JedEye address
+   * @param bt_device  BT (JedEye) device
+   */
+  public JedeyeComm( TopoDroidApp app, String address, BluetoothDevice bt_device )
+  {
+    super( app, address, bt_device, 6 ); // bootstrap as SAP6, then swap UUIDs
+    mServiceUuid   = JedeyeConst.JEDEYE_SERVICE_UUID;
+    mChrtReadUuid  = JedeyeConst.JEDEYE_CHRT_READ_UUID;
+    mChrtWriteUuid = JedeyeConst.JEDEYE_CHRT_WRITE_UUID;
+  }
+
+  /** create the protocol
+   * @param device   BT device
+   */
+  @Override
+  protected void createProtocol( Device device )
+  {
+    mSapProto = new JedeyeProtocol( this, device, mContext );
+  }
+
+  /** SapComm.assertDevice is widened to protected so we can recognise JedEye
+   * here without polluting the SAP package with JedEye knowledge.
+   * @param device  bluetooth device
+   * @return true if the device is JedEye (correct UUIDs are in place)
+   */
+  @Override
+  protected boolean assertDevice( Device device )
+  {
+    if ( device.isJedeye() ) {
+      assert( mServiceUuid   == JedeyeConst.JEDEYE_SERVICE_UUID );
+      assert( mChrtReadUuid  == JedeyeConst.JEDEYE_CHRT_READ_UUID );
+      assert( mChrtWriteUuid == JedeyeConst.JEDEYE_CHRT_WRITE_UUID );
+      return true;
+    }
+    return super.assertDevice( device );
+  }
+}

--- a/src/com/topodroid/dev/jedeye/JedeyeComm.java
+++ b/src/com/topodroid/dev/jedeye/JedeyeComm.java
@@ -18,7 +18,6 @@ import com.topodroid.TDX.TopoDroidApp;
 import com.topodroid.dev.Device;
 import com.topodroid.dev.sap.SapComm;
 
-import android.content.Context;
 import android.bluetooth.BluetoothDevice;
 
 public class JedeyeComm extends SapComm

--- a/src/com/topodroid/dev/jedeye/JedeyeConst.java
+++ b/src/com/topodroid/dev/jedeye/JedeyeConst.java
@@ -1,0 +1,29 @@
+/* @file JedeyeConst.java
+ *
+ * @author sebastien kister
+ * @date 2026
+ *
+ * @brief TopoDroid JedEye bluetooth LE constants
+ * --------------------------------------------------------
+ *  Copyright This software is distributed under GPL-3.0 or later
+ *  See the file COPYING.
+ * --------------------------------------------------------
+ *
+ * JedEye uses the SAP6 17-byte shot frame and DistoX2/SAP6 single-byte
+ * command set, but advertises its own 128-bit GATT UUIDs so it has a
+ * distinct identity in BLE scanners.
+ */
+package com.topodroid.dev.jedeye;
+
+import java.util.UUID;
+
+public class JedeyeConst
+{
+  static final String JEDEYE_SRV_UUID_STR        = "4a454445-5945-0001-8000-00805f9b34fb"; // service
+  static final String JEDEYE_CHRT_READ_UUID_STR  = "4a454445-5945-0002-8000-00805f9b34fb"; // notify (device -> app)
+  static final String JEDEYE_CHRT_WRITE_UUID_STR = "4a454445-5945-0003-8000-00805f9b34fb"; // write  (app -> device)
+
+  static final public UUID JEDEYE_SERVICE_UUID    = UUID.fromString( JEDEYE_SRV_UUID_STR );
+  static final public UUID JEDEYE_CHRT_READ_UUID  = UUID.fromString( JEDEYE_CHRT_READ_UUID_STR );
+  static final public UUID JEDEYE_CHRT_WRITE_UUID = UUID.fromString( JEDEYE_CHRT_WRITE_UUID_STR );
+}

--- a/src/com/topodroid/dev/jedeye/JedeyeProtocol.java
+++ b/src/com/topodroid/dev/jedeye/JedeyeProtocol.java
@@ -1,0 +1,35 @@
+/* @file JedeyeProtocol.java
+ *
+ * @author sebastien kister
+ * @date 2026
+ *
+ * @brief TopoDroid JedEye BLE protocol
+ * --------------------------------------------------------
+ *  Copyright This software is distributed under GPL-3.0 or later
+ *  See the file COPYING.
+ * --------------------------------------------------------
+ *
+ * JedEye uses the SAP6 17-byte shot frame (sequence byte + four little-endian
+ * float32 = bearing/clino/roll/distance). All parsing is therefore inherited
+ * from SapProtocol; this subclass only exists so the Device-type dispatch in
+ * SapProtocol.handleRead() correctly identifies JedEye as SAP6-shaped data.
+ */
+package com.topodroid.dev.jedeye;
+
+import com.topodroid.dev.Device;
+import com.topodroid.dev.sap.SapProtocol;
+
+import android.content.Context;
+
+class JedeyeProtocol extends SapProtocol
+{
+  /** cstr
+   * @param comm    communication class
+   * @param device  BT device
+   * @param context context
+   */
+  JedeyeProtocol( JedeyeComm comm, Device device, Context context )
+  {
+    super( comm, device, context );
+  }
+}

--- a/src/com/topodroid/dev/sap/SapComm.java
+++ b/src/com/topodroid/dev/sap/SapComm.java
@@ -124,7 +124,7 @@ public class SapComm extends BleComm
   // CONNECTION AND DATA HANDLING MUST RUN ON A SEPARATE THREAD
   // 
 
-  private boolean assertDevice( Device device )
+  protected boolean assertDevice( Device device )
   {
     if ( device.isSap5() ) {
       assert( mServiceUuid   == SapConst.SAP5_SERVICE_UUID );

--- a/src/com/topodroid/dev/sap/SapComm.java
+++ b/src/com/topodroid/dev/sap/SapComm.java
@@ -431,8 +431,8 @@ public class SapComm extends BleComm
       TDLog.v( "SAP comm: changed chrt READ" );
       int res = mSapProto.handleReadNotify( chrt );
       if ( res == DataType.PACKET_DATA ) {
-        // if ( uuid_str.equals( SapConst.SAP6_CHRT_READ_UUID_STR )) 
-        if ( uuid.compareTo( SapConst.SAP6_CHRT_READ_UUID ) == 0 ) { // model SAP^ send ack
+        // if ( uuid_str.equals( SapConst.SAP6_CHRT_READ_UUID_STR ))
+        if ( uuid.compareTo( SapConst.SAP6_CHRT_READ_UUID ) == 0 ) { // model SAP6: send ack (JedEye does not use the ACK handshake)
           byte[] ackByte = mSapProto.handleWrite(); // ACKNOWLEDGMENT
           mCallback.writeChrt( mServiceUuid, mChrtWriteUuid, ackByte );
         }
@@ -440,7 +440,7 @@ public class SapComm extends BleComm
       }
       // readSapPacket();
     // } else if ( uuid_str.equals( SapConst.SAP5_CHRT_WRITE_UUID_STR ) ) {
-    } if ( uuid.compareTo( mChrtWriteUuid ) == 0 ) {
+    } else if ( uuid.compareTo( mChrtWriteUuid ) == 0 ) {
       TDLog.v( "SAP comm: changed chrt WRITE" );
       byte[] bytes = mSapProto.handleWriteNotify( chrt );
       if ( bytes != null ) {

--- a/src/com/topodroid/dev/sap/SapProtocol.java
+++ b/src/com/topodroid/dev/sap/SapProtocol.java
@@ -105,7 +105,7 @@ public class SapProtocol extends TopoDroidProtocol
         if ( (buffer[2] & 0x80) == 0x80 ) buffer[0] &= 0xbf; // clear 0x40
       }
       return handlePacket( buffer );
-    } else if ( Device.isSap6( mDeviceType ) ) { // FIXME_SAP6
+    } else if ( Device.isSap6( mDeviceType ) || Device.isJedeye( mDeviceType ) ) { // FIXME_SAP6 // JedEye reuses SAP6 wire format
       {
         StringBuilder sb = new StringBuilder();
         for ( int k=0; k<bytes.length; ++k ) sb.append( String.format(" %02x", bytes[k] ) );


### PR DESCRIPTION
Adds support for the **JedEye** cave-survey instrument (https://sebkister.github.io/JedEye-Documentation) as a recognised BLE device in TopoDroid.

JedEye is an Arduino-based handheld instrument (Nano RP2040 Connect / NINA-W102 radio) that measures azimuth, clino, roll and distance. Its firmware uses the same 17-byte shot frame as the SAP6 (sequence byte + four little-endian `float32`: bearing, clino, roll, distance in metres), but advertises its own 128-bit GATT service UUIDs so it has a distinct identity in BLE scanners.

## Layout

The new device follows the existing **discox** pattern (subclass SAP rather than duplicate it):

- `dev/jedeye/JedeyeConst.java` — service + read/write UUIDs (`4A454445-5945-000{1,2,3}-…`)
- `dev/jedeye/JedeyeComm.java` extends `SapComm` — constructor bootstraps as SAP6 then swaps the three UUIDs; overrides `assertDevice()` to recognise JedEye; overrides `createProtocol()` to create a `JedeyeProtocol`
- `dev/jedeye/JedeyeProtocol.java` extends `SapProtocol` — empty body; the SAP6 frame parsing already does the right thing

For `JedeyeComm` to recognise its own device type, `SapComm.assertDevice()` is widened from `private` to `protected`. `SapProtocol.handleRead()` accepts JedEye on the SAP6 frame branch (`Device.isSap6(...) || Device.isJedeye(...)`). JedEye is not asked to send back an ACK — its firmware does not run the SAP6 ACK handshake — so `SapComm.changedChrt()` keeps the existing SAP6-UUID check around the `writeChrt` of the ACK.

Cross-cutting edits mirror the Cavway X1 / discox additions:

- `dev/Device.java` — `NAME_JEDEYE = "JedEye_"`, `DISTO_JEDEYE = 12`, `isJedeye()` (instance + `int` + `String`), entries in `mModels` / `mModelNames` / `mAdvertisedNames` / `mBleModels` / `typeString` / `typeSimpleString` / `isKnownDevice` / `isBLE`(both) / `btnameToModel` / `btnameToName` / `btnameToType` / `fromName`
- `TDX/TDInstance.java` — `isDeviceJedeye()`; JedEye added to both flavours of `isDeviceBLE`
- `TDX/TopoDroidApp.java` — `new JedeyeComm(...)` branch in both `createComm()` dispatch sites
- `TDX/DeviceActivity.java` — JedEye in the model-display switch and in the BLE-scanner name-prefix handler

A second tiny commit (`SapComm: fix dangling else attaching to the wrong if`) silences a spurious "SAP comm: changed unexpected chrt …" error that fires after every successful read notification on SAP6 / discox / JedEye: the chain in `changedChrt()` was `if (read) {...} if (write) {...} else { error }`, with a missing `else` on the second `if`. Joining the two `if`s makes the `else` only fire for genuinely unexpected UUIDs. Happy to split that commit out into its own PR if you'd prefer.

## Testing

Tested end-to-end on real hardware: TopoDroid (this branch, sideloaded as a debug APK) connecting to a real JedEye device, scanning, pairing, and capturing measurements. Shots arrive correctly (3.79 m / 315.9° / 25.7° in one log) and are inserted as standard `insertDistoXShot(...)` rows with station auto-assignment running normally. Burst of 50+ measurements without disconnects after a NINA firmware update on the device.

No native code, no new resources, no dependency changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)