### PR TITLE
Fix SAP6/JedEye remote commands stalling after the first BLE write

### DIFF
--- a/src/com/topodroid/dev/sap/SapComm.java
+++ b/src/com/topodroid/dev/sap/SapComm.java
@@ -345,19 +345,21 @@ public class SapComm extends BleComm
   // public void addChrt( UUID srv_uuid, BluetoothGattCharacteristic chrt );
   // public void addDesc( UUID srv_uuid, UUID chrt_uuid, BluetoothGattDescriptor desc );
 
-  /** try to write: 
+  /** try to write:
    * get a byte array from the write queue of the protocol and put it on the write chracateristic
+   * @return true if a buffered write was issued, false if the protocol write buffer was empty
    */
-  private void writeAgainChrt( )
+  private boolean writeAgainChrt( )
   {
     byte[] bytes = mSapProto.handleWrite( );
     if ( bytes != null ) {
       TDLog.v( "SAP comm: write chrt - bytes " + bytes.length );
       // mCallback.writeCharacteristic( mWriteChrt );
       mCallback.writeChrt( mServiceUuid, mChrtWriteUuid, bytes );
-    } else { // done with the buffer writing
-      TDLog.v( "SAP comm: write chrt - bytes null");
+      return true;
     }
+    TDLog.v( "SAP comm: write chrt - bytes null");
+    return false;
   }
 
   // -------------------------------------------------------------------------------
@@ -478,7 +480,17 @@ public class SapComm extends BleComm
   {
     TDLog.v( "SAP comm: written chrt ...");
     if ( ! mWriteInitialized ) { error(-4, uuid_str, "writeInit"); return; }
-    writeAgainChrt( ); // try to write again
+    // A characteristic write just completed. If the protocol still has buffered
+    // bytes (e.g. a multi-part SAP6 ACK) send the next chunk; otherwise advance
+    // the BLE ops queue so the next queued operation can run. The base
+    // BleComm.writtenChrt() clears the pending op for exactly this reason;
+    // omitting it here left mQps.mPendingOp set after the first sendCommand()
+    // write, so every later remote command (LASER_ON / LASER_OFF / MEASURE /
+    // DEVICE_OFF) queued forever and never executed -> SAP6/JedEye remote
+    // control and remote "take shot" were dead after the first button press.
+    if ( ! writeAgainChrt( ) ) {
+      mQps.clearPending();
+    }
   }
 
   // FIXME BleComm has mQps.clearPending();

--- a/src/com/topodroid/dev/sap/SapProtocol.java
+++ b/src/com/topodroid/dev/sap/SapProtocol.java
@@ -119,10 +119,16 @@ public class SapProtocol extends TopoDroidProtocol
       byte[] buffer = new byte[16];
       System.arraycopy( bytes, 1, buffer, 0, 16 );
 
-      // ACKNOWLEDGMENT
-      byte[] ack = new byte[1];
-      ack[0] = (byte)( bytes[0] + 0x55 ); // SapConst.SAP_ACK
-      addToWriteBuffer( ack );
+      // ACKNOWLEDGMENT (SAP6 only). JedEye reuses the SAP6 shot frame but does
+      // NOT use the ACK handshake (SapComm.changedChrt only sends the ACK when
+      // the read UUID is the SAP6 one). Buffering an ACK that is never popped
+      // would leak into mWriteBuffer and later get flushed at the wrong time by
+      // writeAgainChrt(), stalling the remote-command queue.
+      if ( Device.isSap6( mDeviceType ) ) {
+        byte[] ack = new byte[1];
+        ack[0] = (byte)( bytes[0] + 0x55 ); // SapConst.SAP_ACK
+        addToWriteBuffer( ack );
+      }
 
       // DATA
       ByteBuffer byte_buffer = ByteBuffer.wrap( buffer ).order(ByteOrder.LITTLE_ENDIAN);


### PR DESCRIPTION
## Problem

SAP6 and JedEye remote control stop responding after the first command. From the remote-control popup (the Bluetooth button in the Shot window), the first `LASER_ON` / `LASER_OFF` / `MEASURE` is sent, but every command after it does nothing — e.g. you can take exactly one remote "Shot", then the button goes dead. Device-initiated shots (the notify path) keep working, which is what makes it look like a device problem rather than an app one.

## Root cause

`SapComm.sendCommand()` enqueues each command write on the `BleOpsQueue` (`mQps`), which marks it as the pending op. The base `BleComm.writtenChrt()` calls `mQps.clearPending()` when a write completes, to release the queue and let the next op run — but `SapComm` overrides `writtenChrt()` and replaces that with `writeAgainChrt()`, which never advances the queue. So after the first command write, `mPendingOp` stays set forever and every later `sendCommand()` just piles into `mOps` and is never transmitted.

A secondary issue specific to JedEye: `SapProtocol.handleRead()` buffers an ACK for JedEye too, but JedEye does not use the ACK handshake (`SapComm.changedChrt()` only sends the ACK when the read UUID is the SAP6 one), so the unsent ACK leaks into `mWriteBuffer` and later flushes at the wrong time via `writeAgainChrt()`, re-stalling the queue.

## Fix

- **`SapComm`**: `writeAgainChrt()` now reports whether it issued a buffered write; `writtenChrt()` advances the ops queue (`clearPending()`) once the protocol write buffer is drained, restoring the base-class contract. At most one write is issued per completion.
- **`SapProtocol.handleRead()`**: only buffer the SAP6 ACK for real SAP6 devices.

## Testing

Verified on hardware over BLE (JedEye, which reuses the SAP6 wire format): before the change only the first remote "Shot" fired; after it, repeated remote Shots all fire with no stalls. The same `SapComm`/`SapProtocol` path drives SAP6, so SAP6 remote control benefits identically; SAP5 and DiscoX are unaffected (DiscoX does not reach the SAP6 ACK branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
