### PR TITLE
Remove legacy Adobe Illustrator SVG namespace from SVG export

### DIFF
--- a/src/com/topodroid/io/svg/DrawingSvgBase.java
+++ b/src/com/topodroid/io/svg/DrawingSvgBase.java
@@ -95,8 +95,8 @@ public class DrawingSvgBase
   protected static final String end_grp = "</g>\n";
   protected static final String end_svg = "</svg>\n";
 
-  protected static final String group_mode_open  = " inkscape:groupmode=\"layer\" i:layer=\"yes\" >\n";
-  protected static final String group_mode_close = " inkscape:groupmode=\"layer\" i:layer=\"yes\" />\n";
+  protected static final String group_mode_open  = " inkscape:groupmode=\"layer\" >\n";
+  protected static final String group_mode_close = " inkscape:groupmode=\"layer\" />\n";
 
   private final static String ALL = "all";
   
@@ -860,7 +860,7 @@ public class DrawingSvgBase
  
   // strings
 
-  protected static final String svg_header = "<svg xmlns:i=\"http://ns.adobe.com/AdobeIllustrator/10.0/\" xmlns:dc=\"http://purl.org/dc/elements/1.1/\" xmlns:cc=\"http://creativecommons.org/ns#\" xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\" xmlns:svg=\"http://www.w3.org/2000/svg\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" xmlns:sodipodi=\"http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd\" xmlns:inkscape=\"http://www.inkscape.org/namespaces/inkscape\" \n";
+  protected static final String svg_header = "<svg xmlns:dc=\"http://purl.org/dc/elements/1.1/\" xmlns:cc=\"http://creativecommons.org/ns#\" xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\" xmlns:svg=\"http://www.w3.org/2000/svg\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" xmlns:sodipodi=\"http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd\" xmlns:inkscape=\"http://www.inkscape.org/namespaces/inkscape\" \n";
 
   protected static final String sodipodi = "  <sodipodi:namedview pagecolor=\"#ffffff\" bordercolor=\"#666666\" borderopacity=\"1\" objecttolerance=\"10\" gridtolerance=\"10\" guidetolerance=\"10\" inkscape:pageopacity=\"0\" inkscape:pageshadow=\"2\" inkscape:window-width=\"auto\" inkscape:window-height=\"auto\" id=\"namedview48\" showgrid=\"false\" inkscape:zoom=\"1\" inkscape:cx=\"auto\" inkscape:cy=\"auto\" inkscape:window-x=\"0\" inkscape:window-y=\"0\" inkscape:window-maximized=\"1\" inkscape:current-layer=\"w2d_Walls_shp\" showborder=\"false\"/>\n";
 


### PR DESCRIPTION
Fixes #173.

`xmlns:i="http://ns.adobe.com/AdobeIllustrator/10.0/"` and the `i:layer="yes"` attribute it enables (written in `DrawingSvgBase.java`'s `svg_header`, `group_mode_open`, and `group_mode_close`) are Illustrator's own legacy (Illustrator 9/10, ~2001) "Preserve Illustrator Editing Capabilities" SVG round-trip signal. It tells Illustrator's **Place** importer "this file was produced by Illustrator itself — reconstruct native layers from it," which routes Place through an old, rarely-exercised code path.

Our SVG export carries the bare hint without the rest of the payload a real Illustrator-authored SVG would include (no `i:extraneous`, no `<foreignObject>`/`i:pgf` blocks). In testing this causes Illustrator's Place importer to misbehave — repeated placement of the same file until Esc is pressed, and missing layers in the placed result — and to crash on Save afterward. File > Open doesn't use that reconstruction path and just ignores the tag, which is why opening the file directly and re-saving as SVG before placing works around the problem.

This namespace was introduced in a8dc8188a ("SVG roundtrip (1)", 2019-10-30) alongside the real Walls-software round-trip feature (`DISTOX_SVG_ROUNDTRIP`, `isRoundTrip()`/`mRoundTrip` in `Symbol.java`/`BrushManager.java`), and is applied unconditionally in both `DrawingSvg.java` and `DrawingSvgWalls.java` regardless of the "SVG program" (Inkscape/Illustrator) or "SVG Roundtrip" preferences — so this fix applies uniformly to all SVG export. No SVG parser exists anywhere in TopoDroid, so nothing internally reads this markup back in. `inkscape:groupmode="layer"` — the part of this same string that's actually functional, for Inkscape's Layers panel — is left untouched.

One related, already-inactive line: `DrawingSvgWalls.java` also writes (currently commented out, since afae4895c in 2022) an `i:pageBounds` attribute that depends on this same `xmlns:i` declaration. It isn't affected by this change either way since it's disabled — but if it's ever re-enabled in the future, `xmlns:i` would need to be restored alongside it, since `i:pageBounds` uses that same namespace prefix.

Minimal, isolated change — 3 lines in `DrawingSvgBase.java`, no other files touched.

**Testing**

- Built a debug APK from this branch (Ant, per the maintainer's build) and installed it on the affected device (Samsung Galaxy Tab Active 2, SM-T397U, Android 9) from issue #173.
- Exported a plot's SVG from the running app, confirmed the exported file has zero occurrences of `xmlns:i`/`i:layer`, and that `inkscape:groupmode="layer"` is still present and correctly formed.
- Placed that export into both Adobe Illustrator (latest Creative Cloud) and Inkscape: single placement (no repeated-place/Esc issue), all layers visible, and the Illustrator document saves normally — all three symptoms from #173 are resolved.
